### PR TITLE
Twisted parent and child services

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -133,9 +133,14 @@ class JunebugApi(object):
                 },
             },
         }))
+    @inlineCallbacks
     def modify_channel(self, request, body, channel_id):
         '''Mondify the channel configuration'''
-        raise NotImplementedError()
+        channel = yield Channel.from_id(
+            self.redis_config, self.amqp_config, channel_id, self.service)
+        returnValue(response(
+            request, 'channel updated', (yield channel.update(body))))
+
 
     @app.route('/channels/<string:channel_id>', methods=['DELETE'])
     def delete_channel(self, request, channel_id):

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -17,6 +17,9 @@ class ApiUsageError(Exception):
 class JunebugApi(object):
     app = Klein()
 
+    def __init__(self, service):
+        self.service = service
+
     @app.handle_errors(ApiUsageError)
     def usage_error(self, request, failure):
         return response(request, 'api usage error', {

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -92,8 +92,9 @@ class JunebugApi(object):
     def create_channel(self, request, body):
         '''Create a channel'''
         channel = Channel(
-            self.redis_config, self.amqp_config, body, parent=self.service)
+            self.redis_config, self.amqp_config, body)
         yield channel.save()
+        yield channel.start(self.service)
         returnValue(response(
             request, 'channel created', (yield channel.status())))
 

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -99,9 +99,13 @@ class JunebugApi(object):
             request, 'channel created', (yield channel.status())))
 
     @app.route('/channels/<string:channel_id>', methods=['GET'])
+    @inlineCallbacks
     def get_channel(self, request, channel_id):
         '''Return the channel configuration and a nested status object'''
-        raise NotImplementedError()
+        channel = yield Channel.from_id(
+            self.redis_config, self.amqp_config, channel_id, self.service)
+        returnValue(response(
+            request, 'channel found', (yield channel.status())))
 
     @app.route('/channels/<string:channel_id>', methods=['POST'])
     @json_body

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -23,9 +23,10 @@ class ApiUsageError(JunebugError):
 class JunebugApi(object):
     app = Klein()
 
-    def __init__(self, service, redis_config):
+    def __init__(self, service, redis_config, amqp_config):
         self.service = service
         self.redis_config = redis_config
+        self.amqp_config = amqp_config
 
     @app.handle_errors(JunebugError)
     def generic_junebug_error(self, request, failure):
@@ -90,7 +91,8 @@ class JunebugApi(object):
     @inlineCallbacks
     def create_channel(self, request, body):
         '''Create a channel'''
-        channel = Channel(self.redis_config, body, parent=self.service)
+        channel = Channel(
+            self.redis_config, self.amqp_config, body, parent=self.service)
         yield channel.save()
         returnValue(response(
             request, 'channel created', (yield channel.status())))

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -141,7 +141,6 @@ class JunebugApi(object):
         returnValue(response(
             request, 'channel updated', (yield channel.update(body))))
 
-
     @app.route('/channels/<string:channel_id>', methods=['DELETE'])
     def delete_channel(self, request, channel_id):
         '''Delete the channel'''

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -127,12 +127,10 @@ class Channel(object):
         channel_redis = yield redis.sub_manager(id)
         properties = yield channel_redis.get('properties')
         if properties is None:
-            yield channel_redis.close_manager()
             raise ChannelNotFound()
         properties = json.loads(properties)
         obj = cls(redis, amqp_config, properties, id)
         obj.transport_worker = parent.getServiceNamed(id)
-        yield channel_redis.close_manager()
         returnValue(obj)
 
     @classmethod

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -113,7 +113,6 @@ class Channel(object):
         redis = RedisManager.from_config(redis_config)
         return redis.smembers('channels')
 
-    @property
     def status(self):
         '''Returns a dict with the configuration and status of the channel'''
         status = deepcopy(self._properties)

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -94,7 +94,6 @@ class Channel(object):
         channel_redis = yield self.redis.sub_manager(self.id)
         yield channel_redis.set('properties', properties)
         yield self.redis.sadd('channels', self.id)
-        yield channel_redis.close_manager()
 
     @inlineCallbacks
     def update(self, properties):
@@ -117,7 +116,6 @@ class Channel(object):
         '''Removes the channel data from redis'''
         channel_redis = yield self.redis.sub_manager(self.id)
         yield channel_redis.delete('properties')
-        yield channel_redis.close_manager()
 
     @classmethod
     @inlineCallbacks

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -6,13 +6,21 @@ from vumi.service import WorkerCreator
 from vumi.servicemaker import VumiOptions
 from vumi.persist.redis_manager import RedisManager
 
+from junebug.error import JunebugError
 
-class ChannelNotFound(Exception):
+
+class ChannelNotFound(JunebugError):
     '''Raised when a channel's data cannot be found.'''
+    name = 'ChannelNotFound'
+    description = 'channel not found',
+    code = http.NOT_FOUND
 
 
-class InvalidChannelType(Exception):
+class InvalidChannelType(JunebugError):
     '''Raised when an invalid channel type is specified'''
+    name = 'InvalidChannelType',
+    description = 'invalid channel type',
+    code = http.BAD_REQUEST
 
 
 transports = {

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -14,14 +14,14 @@ from junebug.error import JunebugError
 class ChannelNotFound(JunebugError):
     '''Raised when a channel's data cannot be found.'''
     name = 'ChannelNotFound'
-    description = 'channel not found',
+    description = 'channel not found'
     code = http.NOT_FOUND
 
 
 class InvalidChannelType(JunebugError):
     '''Raised when an invalid channel type is specified'''
     name = 'InvalidChannelType',
-    description = 'invalid channel type',
+    description = 'invalid channel type'
     code = http.BAD_REQUEST
 
 

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -1,0 +1,79 @@
+from copy import deepcopy
+import json
+import uuid
+from twisted.internet.defer import inlineCallbacks, returnValue
+from vumi.service import WorkerCreator
+from vumi.servicemaker import VumiOptions
+
+
+class ChannelNotFound(Exception):
+    '''Raised when a channel's data cannot be found.'''
+
+
+class InvalidChannelType(Exception):
+    '''Raised when an invalid channel type is specified'''
+
+
+transports = {
+    'telnet': 'vumi.transport.telnet.TelnetServerTransport',
+}
+
+
+class Channel(object):
+    def __init__(self, redis, properties, id=None):
+        '''Creates a new channel. ``redis`` is the redis manager, from which a
+        sub manager is created using the channel id. If the channel id is not
+        supplied, a UUID one is generated. Call ``save`` to save the channel
+        data.'''
+        self._properties, self.id = properties, id
+        if self.id is None:
+            self.id = str(uuid.uuid4())
+        self._redis = redis.sub_manager(self.id)
+
+    def start(self, service):
+        '''Starts the relevant workers for the channel'''
+        class_name = transports.get(self._properties['type'])
+        if class_name is None:
+            raise InvalidChannelType(
+                'Invalid channel type %r, must be one of: %r' % (
+                    self._properties['type'], transports.keys()))
+        workercreator = WorkerCreator(VumiOptions.default_vumi_options)
+        self.transport_worker = workercreator.create_worker(
+            class_name, self._properties['config'])
+        self.transport_worker.setServiceParent(service)
+
+    @inlineCallbacks
+    def stop(self):
+        '''Stops the relevant workers for the channel'''
+        yield self.transport_worker.stopService()
+
+    @inlineCallbacks
+    def save(self):
+        '''Saves the channel data into redis.'''
+        properties = json.dumps(self._properties)
+        yield self._redis.set('properties', properties)
+
+    @inlineCallbacks
+    def delete(self):
+        '''Removes the channel data from redis'''
+        yield self._redis.delete('properties')
+
+    @classmethod
+    @inlineCallbacks
+    def from_id(cls, redis, id):
+        '''Creates a channel by loading the data from redis, given the
+        channel's id'''
+        properties = yield redis.get('%s:properties' % id)
+        if properties is None:
+            raise ChannelNotFound()
+        properties = json.loads(properties)
+        returnValue(cls(redis, properties, id))
+
+    @property
+    def status(self):
+        '''Returns a dict with the configuration and status of the channel'''
+        status = deepcopy(self._properties)
+        status['id'] = self.id
+        # TODO: Implement channel status
+        status['status'] = {}
+        return status

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -5,9 +5,8 @@ import sys
 
 from twisted.internet import reactor
 from twisted.python import log
-from twisted.web.server import Site
 
-from junebug import JunebugApi
+from junebug.service import JunebugService
 
 
 def parse_arguments(args):
@@ -55,11 +54,8 @@ def logging_setup(filename):
 def start_server(interface, port):
     '''Starts a new Junebug HTTP API server on the specified resource and
     port'''
-
-    port = reactor.listenTCP(
-        port, Site(JunebugApi().app.resource()), interface=interface)
-    log.msg('Junebug is listening on %s:%s' % (interface, port))
-    return port
+    service = JunebugService(interface, port)
+    return service.startService()
 
 
 def main():

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -91,7 +91,8 @@ def start_server(interface, port, redis_config, amqp_config):
     '''Starts a new Junebug HTTP API server on the specified resource and
     port'''
     service = JunebugService(interface, port, redis_config, amqp_config)
-    return service.startService()
+    service.startService()
+    return service
 
 
 def main():

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -4,6 +4,7 @@ import logging.handlers
 import sys
 
 from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.python import log
 
 from junebug.service import JunebugService
@@ -87,12 +88,13 @@ def logging_setup(filename):
         logging.getLogger().addHandler(handler)
 
 
+@inlineCallbacks
 def start_server(interface, port, redis_config, amqp_config):
     '''Starts a new Junebug HTTP API server on the specified resource and
     port'''
     service = JunebugService(interface, port, redis_config, amqp_config)
-    service.startService()
-    return service
+    yield service.startService()
+    returnValue(service)
 
 
 def main():

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -26,6 +26,22 @@ def parse_arguments(args):
     parser.add_argument(
         '--log-file', '-l', dest='logfile', default=None, type=str,
         help='The file to log to. Defaults to not logging to a file')
+    parser.add_argument(
+        '--redis-host', '-redish', dest='redis_host', default='localhost',
+        type=str,
+        help='The hostname of the redis instance. Defaults to "localhost"')
+    parser.add_argument(
+        '--redis-port', '-redisp', dest='redis_port', default=6379,
+        type=int,
+        help='The port of the redis instance. Defaults to "6379"')
+    parser.add_argument(
+        '--redis-db', '-redisdb', dest='redis_db', default=0,
+        type=int,
+        help='The database to use for the redis instance. Defaults to "0"')
+    parser.add_argument(
+        '--redis-password', '-redispass', dest='redis_pass', default=None,
+        type=str,
+        help='The password to use for the redis instance. Defaults to "None"')
 
     return parser.parse_args(args)
 
@@ -51,17 +67,23 @@ def logging_setup(filename):
         logging.getLogger().addHandler(handler)
 
 
-def start_server(interface, port):
+def start_server(interface, port, redis_config):
     '''Starts a new Junebug HTTP API server on the specified resource and
     port'''
-    service = JunebugService(interface, port)
+    service = JunebugService(interface, port, redis_config)
     return service.startService()
 
 
 def main():
     args = parse_arguments(sys.argv[1:])
     logging_setup(args.logfile)
-    start_server(args.interface, args.port)
+    redis_config = {
+        'host': args.redis_host,
+        'port': args.redis_port,
+        'db': args.redis_db,
+        'password': args.redis_pass,
+    }
+    start_server(args.interface, args.port, redis_config)
     reactor.run()
 
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -42,6 +42,26 @@ def parse_arguments(args):
         '--redis-password', '-redispass', dest='redis_pass', default=None,
         type=str,
         help='The password to use for the redis instance. Defaults to "None"')
+    parser.add_argument(
+        '--amqp-host', '-amqph', dest='amqp_host', default='127.0.0.1',
+        type=str,
+        help='The hostname of the amqp endpoint. Defaults to "127.0.0.1"')
+    parser.add_argument(
+        '--amqp-vhost', '-amqpvh', dest='amqp_vhost', default='/',
+        type=str,
+        help='The amqp vhost. Defaults to "/"')
+    parser.add_argument(
+        '--amqp-port', '-amqpp', dest='amqp_port', default=5672,
+        type=int,
+        help='The port of the amqp endpoint. Defaults to "5672"')
+    parser.add_argument(
+        '--amqp-user', '-amqpu', dest='amqp_user', default='guest',
+        type=str,
+        help='The username to use for the amqp auth. Defaults to "guest"')
+    parser.add_argument(
+        '--amqp-password', '-amqppass', dest='amqp_pass', default='guest',
+        type=str,
+        help='The password to use for the amqp auth. Defaults to "guest"')
 
     return parser.parse_args(args)
 
@@ -67,10 +87,10 @@ def logging_setup(filename):
         logging.getLogger().addHandler(handler)
 
 
-def start_server(interface, port, redis_config):
+def start_server(interface, port, redis_config, amqp_config):
     '''Starts a new Junebug HTTP API server on the specified resource and
     port'''
-    service = JunebugService(interface, port, redis_config)
+    service = JunebugService(interface, port, redis_config, amqp_config)
     return service.startService()
 
 
@@ -83,7 +103,14 @@ def main():
         'db': args.redis_db,
         'password': args.redis_pass,
     }
-    start_server(args.interface, args.port, redis_config)
+    amqp_config = {
+        'hostname': args.amqp_host,
+        'vhost': args.amqp_vhost,
+        'port': args.amqp_port,
+        'username': args.amqp_user,
+        'password': args.amqp_pass,
+    }
+    start_server(args.interface, args.port, redis_config, amqp_config)
     reactor.run()
 
 

--- a/junebug/error.py
+++ b/junebug/error.py
@@ -1,0 +1,8 @@
+from twisted.web import http
+
+
+class JunebugError(Exception):
+    '''Generic error from which all other junebug errors inherit from'''
+    name = 'JunebugError'
+    description = 'Generic Junebug Error'
+    code = http.INTERNAL_SERVER_ERROR

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -10,6 +10,7 @@ class JunebugService(MultiService, object):
     '''Base service that runs the HTTP API, and contains transports as child
     services'''
     def __init__(self, interface, port, redis_config):
+        super(JunebugService, self).__init__()
         self.interface = interface
         self.port = port
         self.redis_config = redis_config

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -1,0 +1,26 @@
+from twisted.application.service import MultiService
+from twisted.internet import reactor
+from twisted.python import log
+from twisted.web.server import Site
+
+from junebug import JunebugApi
+
+
+class JunebugService(MultiService, object):
+    '''Base service that runs the HTTP API, and contains transports as child
+    services'''
+    def __init__(self, interface, port):
+        self.interface, self.port = interface, port
+
+    def startService(self):
+        '''Starts the HTTP server, and returns the port object that the server
+        is listening on'''
+        self._port = reactor.listenTCP(
+            self.port, Site(JunebugApi(self).app.resource()),
+            interface=self.interface)
+        log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
+        return self._port
+
+    def stopService(self):
+        '''Stops the HTTP server.'''
+        return self._port.stopListening()

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -19,11 +19,10 @@ class JunebugService(MultiService, object):
     def startService(self):
         '''Starts the HTTP server, and returns the port object that the server
         is listening on'''
+        self.api = JunebugApi(
+            self, self.redis_config, self.amqp_config)
         self._port = reactor.listenTCP(
-            self.port, Site(
-                JunebugApi(
-                    self, self.redis_config, self.amqp_config
-                    ).app.resource()),
+            self.port, Site(self.api.app.resource()),
             interface=self.interface)
         log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
         return self._port

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -9,18 +9,21 @@ from junebug import JunebugApi
 class JunebugService(MultiService, object):
     '''Base service that runs the HTTP API, and contains transports as child
     services'''
-    def __init__(self, interface, port, redis_config):
+    def __init__(self, interface, port, redis_config, amqp_config):
         super(JunebugService, self).__init__()
         self.interface = interface
         self.port = port
         self.redis_config = redis_config
+        self.amqp_config = amqp_config
 
     def startService(self):
         '''Starts the HTTP server, and returns the port object that the server
         is listening on'''
         self._port = reactor.listenTCP(
             self.port, Site(
-                JunebugApi(self, self.redis_config).app.resource()),
+                JunebugApi(
+                    self, self.redis_config, self.amqp_config
+                    ).app.resource()),
             interface=self.interface)
         log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
         return self._port

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -9,14 +9,17 @@ from junebug import JunebugApi
 class JunebugService(MultiService, object):
     '''Base service that runs the HTTP API, and contains transports as child
     services'''
-    def __init__(self, interface, port):
-        self.interface, self.port = interface, port
+    def __init__(self, interface, port, redis_config):
+        self.interface = interface
+        self.port = port
+        self.redis_config = redis_config
 
     def startService(self):
         '''Starts the HTTP server, and returns the port object that the server
         is listening on'''
         self._port = reactor.listenTCP(
-            self.port, Site(JunebugApi(self).app.resource()),
+            self.port, Site(
+                JunebugApi(self, self.redis_config).app.resource()),
             interface=self.interface)
         log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
         return self._port

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -1,5 +1,6 @@
 from twisted.application.service import MultiService
 from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
 from twisted.python import log
 from twisted.web.server import Site
 
@@ -16,16 +17,20 @@ class JunebugService(MultiService, object):
         self.redis_config = redis_config
         self.amqp_config = amqp_config
 
+    @inlineCallbacks
     def startService(self):
         '''Starts the HTTP server, and returns the port object that the server
         is listening on'''
         self.api = JunebugApi(
             self, self.redis_config, self.amqp_config)
+        yield self.api.setup()
         self._port = reactor.listenTCP(
             self.port, Site(self.api.app.resource()),
             interface=self.interface)
         log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
 
+    @inlineCallbacks
     def stopService(self):
         '''Stops the HTTP server.'''
-        return self._port.stopListening()
+        yield self.api.teardown()
+        yield self._port.stopListening()

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -25,7 +25,6 @@ class JunebugService(MultiService, object):
             self.port, Site(self.api.app.resource()),
             interface=self.interface)
         log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
-        return self._port
 
     def stopService(self):
         '''Stops the HTTP server.'''

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -21,6 +21,7 @@ class JunebugService(MultiService, object):
     def startService(self):
         '''Starts the HTTP server, and returns the port object that the server
         is listening on'''
+        super(JunebugService, self).startService()
         self.api = JunebugApi(
             self, self.redis_config, self.amqp_config)
         yield self.api.setup()
@@ -34,3 +35,4 @@ class JunebugService(MultiService, object):
         '''Stops the HTTP server.'''
         yield self.api.teardown()
         yield self._port.stopListening()
+        super(JunebugService, self).stopService()

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -1,0 +1,94 @@
+import logging
+from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.trial.unittest import TestCase
+from vumi.tests.helpers import PersistenceHelper, WorkerHelper
+
+from junebug.channel import Channel
+from junebug.service import JunebugService
+
+
+class JunebugTestBase(TestCase):
+    '''Base test case that all junebug tests inherit from. Contains useful
+    helper functions'''
+
+    default_channel_config = {
+            'type': 'telnet',
+            'config': {
+                'transport_name': 'dummy_transport1',
+                'twisted_endpoint': 'tcp:0',
+            },
+            'mo_url': 'http://foo.bar',
+        }
+
+    def patch_logger(self):
+        ''' Patches the logger with an in-memory logger, which is acccessable
+        at "self.logging_handler".'''
+        self.logging_handler = logging.handlers.MemoryHandler(100)
+        logging.getLogger().addHandler(self.logging_handler)
+        self.addCleanup(self._cleanup_logging_patch)
+
+    def _cleanup_logging_patch(self):
+        self.logging_handler.close()
+        logging.getLogger().removeHandler(self.logging_handler)
+
+    @inlineCallbacks
+    def create_channel(
+            self, service, redis, transport_class,
+            config=default_channel_config, id=None):
+        '''Creates and starts, and saves a channel, with a
+        TelnetServerTransport transport'''
+        channel = Channel(redis._config, {}, config, id=id)
+        config['config']['worker_name'] = channel.id
+        transport_worker = yield WorkerHelper().get_worker(
+            transport_class, config['config'])
+        yield channel.start(self.service, transport_worker)
+        yield channel.save()
+        self.addCleanup(channel.stop)
+        returnValue(channel)
+
+    def create_channel_from_id(self, service, redis, id):
+        '''Creates an existing channel given the channel id'''
+        return Channel.from_id(redis._config, {}, id, service)
+
+    @inlineCallbacks
+    def get_redis(self):
+        '''Creates and returns a redis manager'''
+        if hasattr(self, 'redis'):
+            returnValue(self.redis)
+        persistencehelper = PersistenceHelper()
+        yield persistencehelper.setup()
+        self.redis = yield persistencehelper.get_redis_manager()
+        returnValue(self.redis)
+
+    @inlineCallbacks
+    def start_server(self):
+        '''Starts a junebug server. Stores the service to "self.service", and
+        the url at "self.url"'''
+        redis = yield self.get_redis()
+        self.service = JunebugService('localhost', 0, redis._config, {})
+        server = yield self.service.startService()
+        addr = server.getHost()
+        self.url = "http://%s:%s" % (addr.host, addr.port)
+        self.addCleanup(self.service.stopService)
+
+    @inlineCallbacks
+    def patch_worker_creation(
+            self, transport_class, config=default_channel_config):
+        '''Patches the channel start function to start a worker with the given
+        worker class and config using a worker helper.'''
+        worker_helper = WorkerHelper()
+        transport_worker = yield worker_helper.get_worker(
+            transport_class, config['config'])
+        yield transport_worker.startService()
+        self.addCleanup(transport_worker.stopService)
+        self._original_channel_start = old_start = Channel.start
+
+        def new_start(self, service):
+            return old_start(
+                self, service, transport_worker)
+
+        Channel.start = new_start
+        self.addCleanup(self._unpatch_worker_creation)
+
+    def _unpatch_worker_creation(self):
+        Channel.start = self._original_channel_start

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import logging
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.trial.unittest import TestCase
@@ -37,6 +38,7 @@ class JunebugTestBase(TestCase):
             config=default_channel_config, id=None):
         '''Creates and starts, and saves a channel, with a
         TelnetServerTransport transport'''
+        config = deepcopy(config)
         channel = Channel(redis._config, {}, config, id=id)
         config['config']['worker_name'] = channel.id
         transport_worker = yield WorkerHelper().get_worker(

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -13,13 +13,13 @@ class JunebugTestBase(TestCase):
     helper functions'''
 
     default_channel_config = {
-            'type': 'telnet',
-            'config': {
-                'transport_name': 'dummy_transport1',
-                'twisted_endpoint': 'tcp:0',
-            },
-            'mo_url': 'http://foo.bar',
-        }
+        'type': 'telnet',
+        'config': {
+            'transport_name': 'dummy_transport1',
+            'twisted_endpoint': 'tcp:0',
+        },
+        'mo_url': 'http://foo.bar',
+    }
 
     def patch_logger(self):
         ''' Patches the logger with an in-memory logger, which is acccessable

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -68,7 +68,8 @@ class JunebugTestBase(TestCase):
         the url at "self.url"'''
         redis = yield self.get_redis()
         self.service = JunebugService('localhost', 0, redis._config, {})
-        server = yield self.service.startService()
+        yield self.service.startService()
+        server = self.service._port
         addr = server.getHost()
         self.url = "http://%s:%s" % (addr.host, addr.port)
         self.addCleanup(self.service.stopService)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -39,7 +39,7 @@ class JunebugTestBase(TestCase):
         '''Creates and starts, and saves a channel, with a
         TelnetServerTransport transport'''
         config = deepcopy(config)
-        channel = Channel(redis._config, {}, config, id=id)
+        channel = Channel(redis, {}, config, id=id)
         config['config']['worker_name'] = channel.id
         transport_worker = yield WorkerHelper().get_worker(
             transport_class, config['config'])
@@ -50,7 +50,7 @@ class JunebugTestBase(TestCase):
 
     def create_channel_from_id(self, service, redis, id):
         '''Creates an existing channel given the channel id'''
-        return Channel.from_id(redis._config, {}, id, service)
+        return Channel.from_id(redis, {}, id, service)
 
     @inlineCallbacks
     def get_redis(self):
@@ -60,6 +60,7 @@ class JunebugTestBase(TestCase):
         persistencehelper = PersistenceHelper()
         yield persistencehelper.setup()
         self.redis = yield persistencehelper.get_redis_manager()
+        self.addCleanup(persistencehelper.cleanup)
         returnValue(self.redis)
 
     @inlineCallbacks

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -1,13 +1,11 @@
 import json
 import logging
 import treq
-from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 from twisted.web import http
-from twisted.web.server import Site
 
-from junebug.api import JunebugApi
+from junebug.service import JunebugService
 
 
 class TestJunebugApi(TestCase):
@@ -25,14 +23,14 @@ class TestJunebugApi(TestCase):
 
     @inlineCallbacks
     def start_server(self):
-        self.app = JunebugApi()
-        self.server = yield reactor.listenTCP(0, Site(self.app.app.resource()))
+        self.service = JunebugService('localhost', 0)
+        self.server = yield self.service.startService()
         addr = self.server.getHost()
         self.url = "http://%s:%s" % (addr.host, addr.port)
 
     @inlineCallbacks
     def stop_server(self):
-        yield self.server.loseConnection()
+        yield self.service.stopService()
 
     def get(self, url):
         return treq.get("%s%s" % (self.url, url), persistent=False)

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -27,7 +27,7 @@ class TestJunebugApi(TestCase):
 
     @inlineCallbacks
     def start_server(self):
-        self.service = JunebugService('localhost', 0, self.redis._config)
+        self.service = JunebugService('localhost', 0, self.redis._config, {})
         self.server = yield self.service.startService()
         addr = self.server.getHost()
         self.url = "http://%s:%s" % (addr.host, addr.port)

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -160,14 +160,29 @@ class TestJunebugApi(TestCase):
             })
 
     @inlineCallbacks
-    def test_get_channel(self):
+    def test_get_missing_channel(self):
         resp = yield self.get('/channels/foo-bar')
         yield self.assert_response(
-            resp, http.INTERNAL_SERVER_ERROR, 'generic error', {
+            resp, http.NOT_FOUND, 'channel not found', {
                 'errors': [{
                     'message': '',
-                    'type': 'NotImplementedError',
+                    'type': 'ChannelNotFound',
                 }]
+            })
+
+    @inlineCallbacks
+    def test_get_channel(self):
+        channel = Channel(self.redis._config, {}, {
+            'type': 'telnet',
+            }, 'test-channel')
+        yield channel.save()
+        yield channel.start(self.service)
+        resp = yield self.get('/channels/test-channel')
+        yield self.assert_response(
+            resp, http.OK, 'channel found', {
+                'status': {},
+                'type': 'telnet',
+                'id': 'test-channel'
             })
 
     @inlineCallbacks

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -1,14 +1,10 @@
 from copy import deepcopy
 import json
-import logging
 import treq
 from twisted.internet.defer import inlineCallbacks
-from twisted.trial.unittest import TestCase
 from twisted.web import http
-from vumi.tests.helpers import PersistenceHelper, WorkerHelper
 from vumi.transports.telnet import TelnetServerTransport
 
-from junebug.service import JunebugService
 from junebug.channel import Channel
 from junebug.tests.helpers import JunebugTestBase
 
@@ -167,7 +163,7 @@ class TestJunebugApi(JunebugTestBase):
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post(
-                '/channels/test-channel', {'metadata': {'foo': 'bar'}})
+            '/channels/test-channel', {'metadata': {'foo': 'bar'}})
         expected = deepcopy(self.default_channel_config)
         expected.update({
             'status': {},
@@ -185,7 +181,7 @@ class TestJunebugApi(JunebugTestBase):
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post(
-                '/channels/test-channel', {'config': {'name': 'bar'}})
+            '/channels/test-channel', {'config': {'name': 'bar'}})
         expected = deepcopy(self.default_channel_config)
         expected.update({
             'status': {},

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -129,10 +129,9 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_get_channel(self):
-        self.maxDiff = None
         redis = yield self.get_redis()
         channel = Channel(
-            redis._config, {}, self.default_channel_config, u'test-channel')
+            redis, {}, self.default_channel_config, u'test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.get('/channels/test-channel')
@@ -159,7 +158,7 @@ class TestJunebugApi(JunebugTestBase):
     def test_modify_channel_no_config_change(self):
         redis = yield self.get_redis()
         channel = Channel(
-            redis._config, {}, self.default_channel_config, 'test-channel')
+            redis, {}, self.default_channel_config, 'test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post(
@@ -177,7 +176,7 @@ class TestJunebugApi(JunebugTestBase):
     def test_modify_channel_config_change(self):
         redis = yield self.get_redis()
         channel = Channel(
-            redis._config, {}, self.default_channel_config, 'test-channel')
+            redis, {}, self.default_channel_config, 'test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post(

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -50,6 +50,24 @@ class TestChannel(JunebugTestBase):
             self.service.namedServices[channel.id], channel.transport_worker)
 
     @inlineCallbacks
+    def test_update_channel(self):
+        self.maxDiff = None
+        redis = yield self.get_redis()
+        channel = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
+        self.assertEqual(
+            self.service.namedServices[channel.id], channel.transport_worker)
+
+        update = yield channel.update({'foo': 'bar'})
+        expected = deepcopy(self.default_channel_config)
+        expected.update({
+            'foo': 'bar',
+            'status': {},
+            'id': channel.id,
+            })
+        self.assertEqual(update, expected)
+
+    @inlineCallbacks
     def test_stop_channel(self):
         redis = yield self.get_redis()
         channel = yield self.create_channel(

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import json
 import logging
 from twisted.internet.defer import inlineCallbacks
@@ -5,6 +6,7 @@ from twisted.trial.unittest import TestCase
 from vumi.tests.helpers import PersistenceHelper
 
 from junebug.channel import Channel, ChannelNotFound
+from junebug.service import JunebugService
 
 
 class TestJunebugApi(TestCase):
@@ -15,6 +17,15 @@ class TestJunebugApi(TestCase):
         self.redis = yield self.persistencehelper.get_redis_manager()
         self.logging_handler = logging.handlers.MemoryHandler(100)
         logging.getLogger().addHandler(self.logging_handler)
+        self.test_config = {
+            'type': 'telnet',
+            'config': {
+                'transport_name': 'dummy_transport1',
+                'twisted_endpoint': 'tcp:0',
+            },
+            'mo_url': 'http://foo.bar',
+            }
+        self.service = JunebugService('localhost', 0, self.redis._config)
 
     def tearDown(self):
         self.logging_handler.close()
@@ -22,17 +33,17 @@ class TestJunebugApi(TestCase):
 
     @inlineCallbacks
     def test_save_channel(self):
-        channel = Channel(self.redis._config, {'label': 'test'})
+        channel = Channel(self.redis._config, self.test_config)
         yield channel.save()
         properties = yield self.redis.get('%s:properties' % channel.id)
-        self.assertEqual(json.loads(properties), {'label': 'test'})
+        self.assertEqual(json.loads(properties), self.test_config)
 
     @inlineCallbacks
     def test_delete_channel(self):
-        channel = Channel(self.redis._config, {'label': 'test'})
+        channel = Channel(self.redis._config, self.test_config)
         yield channel.save()
         properties = yield self.redis.get('%s:properties' % channel.id)
-        self.assertEqual(json.loads(properties), {'label': 'test'})
+        self.assertEqual(json.loads(properties), self.test_config)
 
         yield channel.delete()
         properties = yield self.redis.get('%s:properties' % channel.id)
@@ -40,36 +51,38 @@ class TestJunebugApi(TestCase):
 
     @inlineCallbacks
     def test_create_channel_from_id(self):
-        channel1 = Channel(self.redis._config, {'label': 'test'})
+        channel1 = Channel(
+            self.redis._config, self.test_config, parent=self.service)
         yield channel1.save()
 
-        channel2 = yield Channel.from_id(self.redis._config, channel1.id)
+        channel2 = yield Channel.from_id(
+            self.redis._config, channel1.id, self.service)
         self.assertEqual(channel1.status, channel2.status)
 
     @inlineCallbacks
     def test_create_channel_from_unknown_id(self):
         yield self.assertFailure(
-            Channel.from_id(self.redis._config, 'foobar'), ChannelNotFound)
+            Channel.from_id(
+                self.redis._config, 'foobar', None), ChannelNotFound)
 
     def test_channel_status(self):
-        channel = Channel(self.redis._config, {'label': 'test'}, 'channel-id')
-        self.assertEqual(channel.status, {
-            'id': 'channel-id',
-            'label': 'test',
-            'status': {}
-        })
+        channel = Channel(self.redis._config, self.test_config, 'channel-id')
+        expected_response = deepcopy(self.test_config)
+        expected_response['id'] = 'channel-id'
+        expected_response['status'] = {}
+        self.assertEqual(channel.status, expected_response)
 
     @inlineCallbacks
     def test_get_all_channels(self):
         channels = yield Channel.get_all(self.redis._config)
         self.assertEqual(channels, set())
 
-        channel1 = Channel(self.redis._config, {})
+        channel1 = Channel(self.redis._config, self.test_config)
         yield channel1.save()
         channels = yield Channel.get_all(self.redis._config)
         self.assertEqual(channels, set([channel1.id]))
 
-        channel2 = Channel(self.redis._config, {})
+        channel2 = Channel(self.redis._config, self.test_config)
         yield channel2.save()
         channels = yield Channel.get_all(self.redis._config)
         self.assertEqual(channels, set([channel1.id, channel2.id]))

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -1,8 +1,6 @@
 from copy import deepcopy
 import json
-from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.trial.unittest import TestCase
-from vumi.tests.helpers import PersistenceHelper, WorkerHelper
+from twisted.internet.defer import inlineCallbacks
 from vumi.transports.telnet import TelnetServerTransport
 
 from junebug.channel import Channel, ChannelNotFound, InvalidChannelType
@@ -116,7 +114,7 @@ class TestChannel(JunebugTestBase):
         redis = yield self.get_redis()
         channel = yield self.create_channel(
             self.service, redis, TelnetServerTransport, id='channel-id')
-        expected= deepcopy(self.default_channel_config)
+        expected = deepcopy(self.default_channel_config)
         expected.update({
             'id': 'channel-id',
             'status': {},

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import json
-import logging
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.trial.unittest import TestCase
 from vumi.tests.helpers import PersistenceHelper, WorkerHelper
@@ -8,76 +7,53 @@ from vumi.transports.telnet import TelnetServerTransport
 
 from junebug.channel import Channel, ChannelNotFound
 from junebug.service import JunebugService
+from junebug.tests.helpers import JunebugTestBase
 
 
-class TestChannel(TestCase):
+class TestChannel(JunebugTestBase):
     @inlineCallbacks
     def setUp(self):
-        self.persistencehelper = PersistenceHelper()
-        yield self.persistencehelper.setup()
-        self.redis = yield self.persistencehelper.get_redis_manager()
-        self.logging_handler = logging.handlers.MemoryHandler(100)
-        logging.getLogger().addHandler(self.logging_handler)
-        self.test_config = {
-            'type': 'telnet',
-            'config': {
-                'transport_name': 'dummy_transport1',
-                'twisted_endpoint': 'tcp:0',
-            },
-            'mo_url': 'http://foo.bar',
-            }
+        self.patch_logger()
+
+        redis = yield self.get_redis()
         self.service = JunebugService(
-            'localhost', 0, self.redis._config, {})
+            'localhost', 0, redis._config, {})
         yield self.service.startService()
         self.addCleanup(self.service.stopService)
-        self.worker_helper = WorkerHelper()
-
-    def tearDown(self):
-        self.logging_handler.close()
-        logging.getLogger().removeHandler(self.logging_handler)
-
-    @inlineCallbacks
-    def create_channel(self, config=None, id=None):
-        if config is None:
-            config = self.test_config
-        channel = Channel(
-            self.redis._config, {}, config, id=id)
-        transport_worker = yield self.worker_helper.get_worker(
-            TelnetServerTransport, self.test_config['config'])
-        yield channel.start(self.service, transport_worker)
-        self.addCleanup(channel.stop)
-        returnValue(channel)
-
-    def create_channel_from_id(self, id):
-        return Channel.from_id(self.redis._config, {}, id, self.service)
 
     @inlineCallbacks
     def test_save_channel(self):
-        channel = yield self.create_channel()
-        yield channel.save()
-        properties = yield self.redis.get('%s:properties' % channel.id)
-        self.assertEqual(json.loads(properties), self.test_config)
+        redis = yield self.get_redis()
+        channel = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
+        properties = yield redis.get('%s:properties' % channel.id)
+        self.assertEqual(json.loads(properties), self.default_channel_config)
 
     @inlineCallbacks
     def test_delete_channel(self):
-        channel = yield self.create_channel()
-        yield channel.save()
-        properties = yield self.redis.get('%s:properties' % channel.id)
-        self.assertEqual(json.loads(properties), self.test_config)
+        redis = yield self.get_redis()
+        channel = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
+        properties = yield redis.get('%s:properties' % channel.id)
+        self.assertEqual(json.loads(properties), self.default_channel_config)
 
         yield channel.delete()
-        properties = yield self.redis.get('%s:properties' % channel.id)
+        properties = yield redis.get('%s:properties' % channel.id)
         self.assertEqual(properties, None)
 
     @inlineCallbacks
     def test_start_channel(self):
-        channel = yield self.create_channel()
+        redis = yield self.get_redis()
+        channel = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
         self.assertEqual(
             self.service.namedServices[channel.id], channel.transport_worker)
 
     @inlineCallbacks
     def test_stop_channel(self):
-        channel = yield self.create_channel()
+        redis = yield self.get_redis()
+        channel = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
         self.assertEqual(
             self.service.namedServices[channel.id], channel.transport_worker)
 
@@ -86,37 +62,44 @@ class TestChannel(TestCase):
 
     @inlineCallbacks
     def test_create_channel_from_id(self):
-        channel1 = yield self.create_channel()
-        yield channel1.save()
+        redis = yield self.get_redis()
+        channel1 = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
 
-        channel2 = yield self.create_channel_from_id(channel1.id)
+        channel2 = yield self.create_channel_from_id(
+            self.service, redis, channel1.id)
         self.assertEqual((yield channel1.status()), (yield channel2.status()))
 
     @inlineCallbacks
     def test_create_channel_from_unknown_id(self):
+        redis = yield self.get_redis()
         yield self.assertFailure(
-            self.create_channel_from_id('unknown-id'),
+            self.create_channel_from_id(
+                self.service, redis, 'unknown-id'),
             ChannelNotFound)
 
     @inlineCallbacks
     def test_channel_status(self):
-        channel = yield self.create_channel(id='channel-id')
-        expected_response = deepcopy(self.test_config)
+        redis = yield self.get_redis()
+        channel = yield self.create_channel(
+            self.service, redis, TelnetServerTransport, id='channel-id')
+        expected_response = deepcopy(self.default_channel_config)
         expected_response['id'] = 'channel-id'
         expected_response['status'] = {}
         self.assertEqual((yield channel.status()), expected_response)
 
     @inlineCallbacks
     def test_get_all_channels(self):
-        channels = yield Channel.get_all(self.redis._config)
+        redis = yield self.get_redis()
+        channels = yield Channel.get_all(redis._config)
         self.assertEqual(channels, set())
 
-        channel1 = yield self.create_channel()
-        yield channel1.save()
-        channels = yield Channel.get_all(self.redis._config)
+        channel1 = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
+        channels = yield Channel.get_all(redis._config)
         self.assertEqual(channels, set([channel1.id]))
 
-        channel2 = yield self.create_channel()
-        yield channel2.save()
-        channels = yield Channel.get_all(self.redis._config)
+        channel2 = yield self.create_channel(
+            self.service, redis, TelnetServerTransport)
+        channels = yield Channel.get_all(redis._config)
         self.assertEqual(channels, set([channel1.id, channel2.id]))

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -57,7 +57,7 @@ class TestJunebugApi(TestCase):
 
         channel2 = yield Channel.from_id(
             self.redis._config, channel1.id, self.service)
-        self.assertEqual(channel1.status, channel2.status)
+        self.assertEqual((yield channel1.status()), (yield channel2.status()))
 
     @inlineCallbacks
     def test_create_channel_from_unknown_id(self):
@@ -65,12 +65,13 @@ class TestJunebugApi(TestCase):
             Channel.from_id(
                 self.redis._config, 'foobar', None), ChannelNotFound)
 
+    @inlineCallbacks
     def test_channel_status(self):
         channel = Channel(self.redis._config, self.test_config, 'channel-id')
         expected_response = deepcopy(self.test_config)
         expected_response['id'] = 'channel-id'
         expected_response['status'] = {}
-        self.assertEqual(channel.status, expected_response)
+        self.assertEqual((yield channel.status()), expected_response)
 
     @inlineCallbacks
     def test_get_all_channels(self):

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -1,0 +1,60 @@
+import json
+import logging
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import TestCase
+from vumi.tests.helpers import PersistenceHelper
+
+from junebug.channel import Channel, ChannelNotFound
+
+
+class TestJunebugApi(TestCase):
+    @inlineCallbacks
+    def setUp(self):
+        self.persistencehelper = PersistenceHelper()
+        yield self.persistencehelper.setup()
+        self.redis = yield self.persistencehelper.get_redis_manager()
+        self.logging_handler = logging.handlers.MemoryHandler(100)
+        logging.getLogger().addHandler(self.logging_handler)
+
+    def tearDown(self):
+        self.logging_handler.close()
+        logging.getLogger().removeHandler(self.logging_handler)
+
+    @inlineCallbacks
+    def test_save_channel(self):
+        channel = Channel(self.redis, {'label': 'test'})
+        yield channel.save()
+        properties = yield self.redis.get('%s:properties' % channel.id)
+        self.assertEqual(json.loads(properties), {'label': 'test'})
+
+    @inlineCallbacks
+    def test_delete_channel(self):
+        channel = Channel(self.redis, {'label': 'test'})
+        yield channel.save()
+        properties = yield self.redis.get('%s:properties' % channel.id)
+        self.assertEqual(json.loads(properties), {'label': 'test'})
+
+        yield channel.delete()
+        properties = yield self.redis.get('%s:properties' % channel.id)
+        self.assertEqual(properties, None)
+
+    @inlineCallbacks
+    def test_create_channel_from_id(self):
+        channel1 = Channel(self.redis, {'label': 'test'})
+        yield channel1.save()
+
+        channel2 = yield Channel.from_id(self.redis, channel1.id)
+        self.assertEqual(channel1.status, channel2.status)
+
+    @inlineCallbacks
+    def test_create_channel_from_unknown_id(self):
+        yield self.assertFailure(
+            Channel.from_id(self.redis, 'foobar'), ChannelNotFound)
+
+    def test_channel_status(self):
+        channel = Channel(self.redis, {'label': 'test'}, 'channel-id')
+        self.assertEqual(channel.status, {
+            'id': 'channel-id',
+            'label': 'test',
+            'status': {}
+        })

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -173,7 +173,8 @@ class TestCommandLine(TestCase):
     def test_start_server(self):
         '''Starting the server should listen on the specified interface and
         port'''
-        port = start_server('localhost', 0, {}, {})
+        service = start_server('localhost', 0, {}, {})
+        port = service._port
         host = port.getHost()
         self.assertEqual(host.host, '127.0.0.1')
         self.assertEqual(host.type, 'TCP')

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -4,9 +4,10 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from junebug.command_line import parse_arguments, logging_setup, start_server
+from junebug.tests.helpers import JunebugTestBase
 
 
-class TestCommandLine(TestCase):
+class TestCommandLine(JunebugTestBase):
     def test_parse_arguments_interface(self):
         '''The interface command line argument can be specified by
         "--interface" and "-i" and has a default value of "localhost"'''
@@ -177,7 +178,8 @@ class TestCommandLine(TestCase):
     def test_start_server(self):
         '''Starting the server should listen on the specified interface and
         port'''
-        service = yield start_server('localhost', 0, {}, {})
+        redis = yield self.get_redis()
+        service = yield start_server('localhost', 0, redis._config, {})
         port = service._port
         host = port.getHost()
         self.assertEqual(host.host, '127.0.0.1')

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -42,6 +42,54 @@ class TestCommandLine(TestCase):
         args = parse_arguments(['-l', 'foo.bar'])
         self.assertEqual(args.logfile, 'foo.bar')
 
+    def test_parse_arguments_redis_host(self):
+        '''The redis host command line argument can be specified by
+        "--redis-host" or "-redish" and has a default value of "localhost"'''
+        args = parse_arguments([])
+        self.assertEqual(args.redis_host, 'localhost')
+
+        args = parse_arguments(['--redis-host', 'foo.bar'])
+        self.assertEqual(args.redis_host, 'foo.bar')
+
+        args = parse_arguments(['-redish', 'foo.bar'])
+        self.assertEqual(args.redis_host, 'foo.bar')
+
+    def test_parse_arguments_redis_port(self):
+        '''The redis port command line argument can be specified by
+        "--redis-port" or "-redisp" and has a default value of 6379'''
+        args = parse_arguments([])
+        self.assertEqual(args.redis_port, 6379)
+
+        args = parse_arguments(['--redis-port', '80'])
+        self.assertEqual(args.redis_port, 80)
+
+        args = parse_arguments(['-redisp', '80'])
+        self.assertEqual(args.redis_port, 80)
+
+    def test_parse_arguments_redis_database(self):
+        '''The redis database command line argument can be specified by
+        "--redis-db" or "-redisdb" and has a default value of 0'''
+        args = parse_arguments([])
+        self.assertEqual(args.redis_db, 0)
+
+        args = parse_arguments(['--redis-db', '80'])
+        self.assertEqual(args.redis_db, 80)
+
+        args = parse_arguments(['-redisdb', '80'])
+        self.assertEqual(args.redis_db, 80)
+
+    def test_parse_arguments_redis_password(self):
+        '''The redis password command line argument can be specified by
+        "--redis-password" or "-redispass" and has a default value of None'''
+        args = parse_arguments([])
+        self.assertEqual(args.redis_pass, None)
+
+        args = parse_arguments(['--redis-password', 'foo.bar'])
+        self.assertEqual(args.redis_pass, 'foo.bar')
+
+        args = parse_arguments(['-redispass', 'foo.bar'])
+        self.assertEqual(args.redis_pass, 'foo.bar')
+
     def test_logging_setup(self):
         '''If filename is None, just a stdout logger is created, if filename
         is not None, both the stdout logger and a file logger is created'''
@@ -65,7 +113,7 @@ class TestCommandLine(TestCase):
     def test_start_server(self):
         '''Starting the server should listen on the specified interface and
         port'''
-        port = start_server('localhost', 0)
+        port = start_server('localhost', 0, {})
         host = port.getHost()
         self.assertEqual(host.host, '127.0.0.1')
         self.assertEqual(host.type, 'TCP')

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -90,6 +90,66 @@ class TestCommandLine(TestCase):
         args = parse_arguments(['-redispass', 'foo.bar'])
         self.assertEqual(args.redis_pass, 'foo.bar')
 
+    def test_parse_arguments_amqp_host(self):
+        '''The amqp host command line argument can be specified by
+        "--amqp-host" or "-amqph" and has a default value of "127.0.0.1"'''
+        args = parse_arguments([])
+        self.assertEqual(args.amqp_host, '127.0.0.1')
+
+        args = parse_arguments(['--amqp-host', 'foo.bar'])
+        self.assertEqual(args.amqp_host, 'foo.bar')
+
+        args = parse_arguments(['-amqph', 'foo.bar'])
+        self.assertEqual(args.amqp_host, 'foo.bar')
+
+    def test_parse_arguments_amqp_port(self):
+        '''The amqp port command line argument can be specified by
+        "--amqp-port" or "-amqpp" and has a default value of 5672'''
+        args = parse_arguments([])
+        self.assertEqual(args.amqp_port, 5672)
+
+        args = parse_arguments(['--amqp-port', '80'])
+        self.assertEqual(args.amqp_port, 80)
+
+        args = parse_arguments(['-amqpp', '80'])
+        self.assertEqual(args.amqp_port, 80)
+
+    def test_parse_arguments_amqp_username(self):
+        '''The amqp username command line argument can be specified by
+        "--amqp-user" or "-amqpu" and has a default value of "guest"'''
+        args = parse_arguments([])
+        self.assertEqual(args.amqp_user, 'guest')
+
+        args = parse_arguments(['--amqp-user', 'test'])
+        self.assertEqual(args.amqp_user, 'test')
+
+        args = parse_arguments(['-amqpu', 'test'])
+        self.assertEqual(args.amqp_user, 'test')
+
+    def test_parse_arguments_amqp_password(self):
+        '''The amqp password command line argument can be specified by
+        "--amqp-password" or "-amqppass" and has a default value of "guest"'''
+        args = parse_arguments([])
+        self.assertEqual(args.amqp_pass, 'guest')
+
+        args = parse_arguments(['--amqp-password', 'foo.bar'])
+        self.assertEqual(args.amqp_pass, 'foo.bar')
+
+        args = parse_arguments(['-amqppass', 'foo.bar'])
+        self.assertEqual(args.amqp_pass, 'foo.bar')
+
+    def test_parse_arguments_amqp_vhost(self):
+        '''The amqp vhost command line argument can be specified by
+        "--amqp-vhost" or "-amqpv" and has a default value of "/"'''
+        args = parse_arguments([])
+        self.assertEqual(args.amqp_vhost, '/')
+
+        args = parse_arguments(['--amqp-vhost', 'foo.bar'])
+        self.assertEqual(args.amqp_vhost, 'foo.bar')
+
+        args = parse_arguments(['-amqpv', 'foo.bar'])
+        self.assertEqual(args.amqp_vhost, 'foo.bar')
+
     def test_logging_setup(self):
         '''If filename is None, just a stdout logger is created, if filename
         is not None, both the stdout logger and a file logger is created'''
@@ -113,11 +173,9 @@ class TestCommandLine(TestCase):
     def test_start_server(self):
         '''Starting the server should listen on the specified interface and
         port'''
-        port = start_server('localhost', 0, {})
+        port = start_server('localhost', 0, {}, {})
         host = port.getHost()
         self.assertEqual(host.host, '127.0.0.1')
         self.assertEqual(host.type, 'TCP')
         self.assertTrue(host.port > 0)
         port.stopListening()
-
-

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -160,12 +160,14 @@ class TestCommandLine(TestCase):
 
         filename = self.mktemp()
         logging_setup(filename)
-        [handler1, handler2] = sorted(logging.getLogger().handlers)
+        [handler1, handler2] = sorted(
+            logging.getLogger().handlers,
+            key=lambda h: hasattr(h, 'baseFilename'))
 
         self.assertEqual(
-            os.path.abspath(handler1.baseFilename),
+            os.path.abspath(handler2.baseFilename),
             os.path.abspath(filename))
-        self.assertEqual(handler2.stream.name, '<stdout>')
+        self.assertEqual(handler1.stream.name, '<stdout>')
 
         logging.getLogger().removeHandler(handler1)
         logging.getLogger().removeHandler(handler2)

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
 from junebug.command_line import parse_arguments, logging_setup, start_server
@@ -172,13 +173,14 @@ class TestCommandLine(TestCase):
         logging.getLogger().removeHandler(handler1)
         logging.getLogger().removeHandler(handler2)
 
+    @inlineCallbacks
     def test_start_server(self):
         '''Starting the server should listen on the specified interface and
         port'''
-        service = start_server('localhost', 0, {}, {})
+        service = yield start_server('localhost', 0, {}, {})
         port = service._port
         host = port.getHost()
         self.assertEqual(host.host, '127.0.0.1')
         self.assertEqual(host.type, 'TCP')
         self.assertTrue(host.port > 0)
-        port.stopListening()
+        yield service.stopService()

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -1,0 +1,16 @@
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import TestCase
+
+from junebug.service import JunebugService
+
+
+class TestJunebugService(TestCase):
+    @inlineCallbacks
+    def test_start_service(self):
+        service = JunebugService('localhost', 0)
+
+        server = yield service.startService()
+        self.assertTrue(server.connected)
+
+        yield service.stopService()
+        self.assertFalse(server.connected)

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -1,6 +1,5 @@
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
-from vumi.tests.fake_amqp import FakeAMQPBroker
 from vumi.tests.helpers import PersistenceHelper
 
 from junebug.service import JunebugService

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -1,5 +1,6 @@
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
+from vumi.tests.fake_amqp import FakeAMQPBroker
 from vumi.tests.helpers import PersistenceHelper
 
 from junebug.service import JunebugService
@@ -14,7 +15,7 @@ class TestJunebugService(TestCase):
 
     @inlineCallbacks
     def test_start_service(self):
-        service = JunebugService('localhost', 0, self.redis._config)
+        service = JunebugService('localhost', 0, self.redis._config, {})
 
         server = yield service.startService()
         self.assertTrue(server.connected)

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -16,7 +16,8 @@ class TestJunebugService(TestCase):
     def test_start_service(self):
         service = JunebugService('localhost', 0, self.redis._config, {})
 
-        server = yield service.startService()
+        yield service.startService()
+        server = service._port
         self.assertTrue(server.connected)
 
         yield service.stopService()

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -1,13 +1,20 @@
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
+from vumi.tests.helpers import PersistenceHelper
 
 from junebug.service import JunebugService
 
 
 class TestJunebugService(TestCase):
     @inlineCallbacks
+    def setUp(self):
+        self.persistencehelper = PersistenceHelper()
+        yield self.persistencehelper.setup()
+        self.redis = yield self.persistencehelper.get_redis_manager()
+
+    @inlineCallbacks
     def test_start_service(self):
-        service = JunebugService('localhost', 0)
+        service = JunebugService('localhost', 0, self.redis._config)
 
         server = yield service.startService()
         self.assertTrue(server.connected)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'klein',
         'jsonschema',
         'treq',
+        'vumi',
     ],
     entry_points='''
     [console_scripts]


### PR DESCRIPTION
Have the junebug API run as a twisted multiservice, and add the machinery to launch transports as child services of the API.