### PR TITLE
Add /s for collection api endpoints

### DIFF
--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -118,7 +118,7 @@ Channels
 Messages
 ^^^^^^^^
 
-.. http:post:: /channels/(channel_id:str)/messages
+.. http:post:: /channels/(channel_id:str)/messages/
 
    Send an outbound (mobile terminated) message.
 

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -18,12 +18,12 @@ HTTP API endpoints
 Channels
 ^^^^^^^^
 
-.. http:get:: /channels
+.. http:get:: /channels/
 
    List all channels
 
 
-.. http:post:: /channels
+.. http:post:: /channels/
 
    Create a channel.
 

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -159,7 +159,7 @@ class JunebugApi(object):
         '''Delete the channel'''
         raise NotImplementedError()
 
-    @app.route('/channels/<string:channel_id>/messages', methods=['POST'])
+    @app.route('/channels/<string:channel_id>/messages/', methods=['POST'])
     @json_body
     @validate(
         body_schema({

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -65,14 +65,14 @@ class JunebugApi(object):
                 }]
             }, code=http.INTERNAL_SERVER_ERROR)
 
-    @app.route('/channels', methods=['GET'])
+    @app.route('/channels/', methods=['GET'])
     @inlineCallbacks
     def get_channel_list(self, request):
         '''List all channels'''
         ids = yield Channel.get_all(self.redis)
         returnValue(response(request, 'channels listed', sorted(ids)))
 
-    @app.route('/channels', methods=['POST'])
+    @app.route('/channels/', methods=['POST'])
     @json_body
     @validate(
         body_schema({

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -235,7 +235,7 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_send_message(self):
-        resp = yield self.post('/channels/foo-bar/messages', {
+        resp = yield self.post('/channels/foo-bar/messages/', {
             'to': '+1234'})
         yield self.assert_response(
             resp, http.INTERNAL_SERVER_ERROR, 'generic error', {
@@ -247,7 +247,7 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_send_message_no_to_or_reply_to(self):
-        resp = yield self.post('/channels/foo-bar/messages', {})
+        resp = yield self.post('/channels/foo-bar/messages/', {})
         yield self.assert_response(
             resp, http.BAD_REQUEST, 'api usage error', {
                 'errors': [{
@@ -258,7 +258,7 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_send_message_both_to_and_reply_to(self):
-        resp = yield self.post('/channels/foo-bar/messages', {
+        resp = yield self.post('/channels/foo-bar/messages/', {
             'to': '+1234',
             'reply_to': '2e8u9ua8',
         })

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -60,19 +60,19 @@ class TestJunebugApi(JunebugTestBase):
         redis = yield self.get_redis()
         config = self.default_channel_config
 
-        resp = yield self.get('/channels')
+        resp = yield self.get('/channels/')
         yield self.assert_response(resp, http.OK, 'channels listed', [])
 
         yield Channel(redis, {}, config, u'test-channel-1').save()
 
-        resp = yield self.get('/channels')
+        resp = yield self.get('/channels/')
         yield self.assert_response(resp, http.OK, 'channels listed', [
             u'test-channel-1',
         ])
 
         yield Channel(redis, {}, config, u'test-channel-2').save()
 
-        resp = yield self.get('/channels')
+        resp = yield self.get('/channels/')
         yield self.assert_response(resp, http.OK, 'channels listed', [
             u'test-channel-1',
             u'test-channel-2',
@@ -80,7 +80,7 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_create_channel(self):
-        resp = yield self.post('/channels', {
+        resp = yield self.post('/channels/', {
             'type': 'telnet',
             'config': self.default_channel_config,
             'mo_url': 'http://foo.bar',
@@ -104,7 +104,7 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_create_channel_invalid_parameters(self):
-        resp = yield self.post('/channels', {
+        resp = yield self.post('/channels/', {
             'type': 'smpp',
             'config': {},
             'rate_limit_count': -3,


### PR DESCRIPTION
To be more RESTful, it would be nice to have collection api endpoints that look like `/channels/` instead of `/channels`.