### PR TITLE
Send a message

### DIFF
--- a/junebug/amqp.py
+++ b/junebug/amqp.py
@@ -70,15 +70,15 @@ class JunebugAMQClient(AMQClient, object):
         self.factory.amqp_client_d.callback(None)
 
     @inlineCallbacks
-    def get_channel(self, channel_id=None):
-        """If channel_id is None a new channel is created"""
-        if channel_id:
-            channel = self.channels[channel_id]
-        else:
+    def get_channel(self):
+        """If channel is None a new channel is created"""
+        if not hasattr(self, 'cached_channel'):
             channel_id = self.get_new_channel_id()
             channel = yield self.channel(channel_id)
             yield channel.channel_open()
-            self.channels[channel_id] = channel
+            self.cached_channel = channel
+        else:
+            channel = self.cached_channel
         returnValue(channel)
 
     def get_new_channel_id(self):

--- a/junebug/amqp.py
+++ b/junebug/amqp.py
@@ -64,6 +64,7 @@ class AmqpFactory(ReconnectingClientFactory, object):
         self.amqp_config = amqp_config
         self.spec = get_spec(vumi_resource_path(specfile))
         self.delegate = TwistedDelegate()
+        super(AmqpFactory, self).__init__()
 
     def buildProtocol(self, addr):
         amqp_client = JunebugAMQClient(

--- a/junebug/amqp.py
+++ b/junebug/amqp.py
@@ -1,6 +1,6 @@
 from twisted.application.internet import TCPClient
 from twisted.application.service import MultiService
-from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.python import log
 from twisted.web import http

--- a/junebug/amqp.py
+++ b/junebug/amqp.py
@@ -1,0 +1,115 @@
+from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.protocol import ReconnectingClientFactory
+from twisted.python import log
+from txamqp.client import TwistedDelegate
+from txamqp.content import Content
+from txamqp.protocol import AMQClient
+from vumi.utils import vumi_resource_path
+from vumi.service import get_spec
+
+
+class AmqpFactory(ReconnectingClientFactory, object):
+    def __init__(self, specfile, amqp_config):
+        '''Factory that creates JunebugAMQClients.
+        specfile - string of specfile name
+        amqp_config - connection details for amqp server
+        '''
+        self.amqp_config = amqp_config
+        self.spec = get_spec(vumi_resource_path(specfile))
+        self.delegate = TwistedDelegate()
+        self.amqp_client_d = Deferred()
+
+    def buildProtocol(self, addr):
+        amqp_client = JunebugAMQClient(
+            self.delegate, self.amqp_config['vhost'],
+            self.spec, self.amqp_config.get('heartbeat', 0))
+        amqp_client.factory = self
+        self.resetDelay()
+        return amqp_client
+
+    def clientConnectionFailed(self, connector, reason):
+        log.err("AmqpFactory connection failed (%s)" % (
+            reason.getErrorMessage(),))
+        super(AmqpFactory, self).clientConnectionFailed(connector, reason)
+
+    def clientConnectionLost(self, connector, reason):
+        log.err("AmqpFactory client connection lost (%s)" % (
+            reason.getErrorMessage(),))
+        self.amqp_client_d = Deferred()
+        super(AmqpFactory, self).clientConnectionLost(connector, reason)
+
+    @inlineCallbacks
+    def get_client(self):
+        '''Returns a deferred that fires with a connected client'''
+        if not self.amqp_client_d.called:
+            yield self.amqp_client_d
+        returnValue(self.amqp_client)
+
+
+class RoutingKeyError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)
+
+
+class JunebugAMQClient(AMQClient, object):
+    exchange_name = "vumi"
+    routing_key = "routing_key"
+    delivery_mode = 2  # save to disk
+
+    @inlineCallbacks
+    def connectionMade(self):
+        super(JunebugAMQClient, self).connectionMade()
+        yield self.authenticate(self.factory.amqp_config['username'],
+                                self.factory.amqp_config['password'])
+        # authentication was successful
+        log.msg("Got an authenticated AMQP connection")
+        self.factory.amqp_client = self
+        self.factory.amqp_client_d.callback(None)
+
+    @inlineCallbacks
+    def get_channel(self, channel_id=None):
+        """If channel_id is None a new channel is created"""
+        if channel_id:
+            channel = self.channels[channel_id]
+        else:
+            channel_id = self.get_new_channel_id()
+            channel = yield self.channel(channel_id)
+            yield channel.channel_open()
+            self.channels[channel_id] = channel
+        returnValue(channel)
+
+    def get_new_channel_id(self):
+        """
+        AMQClient keeps track of channels in a dictionary. The
+        channel ids are the keys, get the highest number and up it
+        or just return zero for the first channel
+        """
+        return (max(self.channels) + 1) if self.channels else 0
+
+    def check_routing_key(self, routing_key):
+        if(routing_key != routing_key.lower()):
+            raise RoutingKeyError("The routing_key: %s is not all lower case!"
+                                  % (routing_key))
+
+    def publish_message(self, message, **kwargs):
+        d = self.publish_raw(message.to_json(), **kwargs)
+        d.addCallback(lambda r: message)
+        return d
+
+    def publish_raw(self, data, **kwargs):
+        amq_message = Content(data)
+        amq_message['delivery mode'] = kwargs.pop(
+            'delivery_mode', self.delivery_mode)
+        return self.publish(amq_message, **kwargs)
+
+    @inlineCallbacks
+    def publish(self, message, **kwargs):
+        exchange_name = kwargs.get('exchange_name') or self.exchange_name
+        routing_key = kwargs.get('routing_key') or self.routing_key
+        self.check_routing_key(routing_key)
+        channel = yield self.get_channel()
+        yield channel.basic_publish(
+            exchange=exchange_name, content=message, routing_key=routing_key)

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -204,4 +204,4 @@ class JunebugApi(object):
 
     @app.route('/health', methods=['GET'])
     def health_status(self, request):
-        returnValue(response(request, 'health ok', {}))
+        return response(request, 'health ok', {})

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -185,6 +185,7 @@ class JunebugApi(object):
                 'channel_data': {'type': 'object'},
             },
             'required': ['from', 'content'],
+            'additionalProperties': False,
         }))
     @inlineCallbacks
     def send_message(self, request, body, channel_id):

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -205,7 +205,7 @@ class JunebugApi(object):
             self.redis, self.amqp_config, channel_id, self.service)
         amqp_client = yield self.amqp_factory.get_client()
         content = body.get('content')
-        msg = yield channel.send_message(amqp_client, channel_id, to_addr, content)
+        msg = yield channel.send_message(amqp_client, to_addr, content)
         returnValue(response(request, 'message sent', msg))
 
     @app.route(

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -1,9 +1,7 @@
-import json
 from klein import Klein
 import logging
 from werkzeug.exceptions import HTTPException
 from twisted.application.internet import TCPClient
-from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web import http
 from vumi.persist.txredis_manager import TxRedisManager
@@ -38,7 +36,8 @@ class JunebugApi(object):
         self.redis = yield TxRedisManager.from_config(self.redis_config)
         self.amqp_factory = AmqpFactory('amqp-spec-0-8.xml', self.amqp_config)
         amqp_service = TCPClient(
-            self.amqp_config['hostname'], self.amqp_config['port'], self.amqp_factory)
+            self.amqp_config['hostname'], self.amqp_config['port'],
+            self.amqp_factory)
         amqp_service.setServiceParent(self.service)
 
     @inlineCallbacks

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -181,7 +181,7 @@ class JunebugApi(object):
                 'to': {'type': 'string'},
                 'from': {'type': ['string', 'null']},
                 'reply_to': {'type': 'string'},
-                'content': {'type': 'string'},
+                'content': {'type': ['string', 'null']},
                 'event_url': {'type': 'string'},
                 'priority': {'type': 'string'},
                 'channel_data': {'type': 'object'},

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -184,7 +184,7 @@ class JunebugApi(object):
                 'priority': {'type': 'string'},
                 'channel_data': {'type': 'object'},
             },
-            'required': ['from'],
+            'required': ['from', 'content'],
         }))
     @inlineCallbacks
     def send_message(self, request, body, channel_id):
@@ -200,8 +200,7 @@ class JunebugApi(object):
 
         channel = yield Channel.from_id(
             self.redis, self.amqp_config, channel_id, self.service)
-        content = body.get('content')
-        msg = yield channel.send_message(self.message_sender, to_addr, content)
+        msg = yield channel.send_message(self.message_sender, body)
         returnValue(response(request, 'message sent', msg))
 
     @app.route(

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -1,7 +1,6 @@
 from klein import Klein
 import logging
 from werkzeug.exceptions import HTTPException
-from twisted.application.internet import TCPClient
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web import http
 from vumi.persist.txredis_manager import TxRedisManager

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -175,7 +175,7 @@ class Channel(object):
         ret['content'] = msg['content']
         ret['transport_name'] = self.id
         channel_data = msg.get('channel_data', {})
-        if channel_data.get('continue_session'):
+        if channel_data.get('continue_session') is not None:
             ret['continue_session'] = channel_data.pop('continue_session')
         ret['helper_metadata'] = channel_data
         return ret

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -154,11 +154,13 @@ class Channel(object):
         return status
 
     @inlineCallbacks
-    def send_message(self, amq_client, to_addr, content, **kw):
+    def send_message(self, message_sender, to_addr, content, **kw):
+        '''Sends a message. Takes a junebug.amqp.MessageSender instance to
+        send a message.'''
         message = TransportUserMessage.send(
             to_addr=to_addr, content=content, transport_name=self.id)
         queue = '%s.outbound' % self.id
-        msg = yield amq_client.publish_message(message, routing_key=queue)
+        msg = yield message_sender.send_message(message, routing_key=queue)
         ret = {}
         for key, val in msg.payload.iteritems():
             if key in allowed_message_fields:

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -162,10 +162,11 @@ class Channel(object):
         ret['timestamp'] = msg['timestamp']
         ret['reply_to'] = msg['in_reply_to']
         ret['content'] = msg['content']
-        ret['session_event'] = msg['session_event']
         ret['channel_data'] = msg['helper_metadata']
         if msg.get('continue_session') is not None:
             ret['channel_data']['continue_session'] = msg['continue_session']
+        if msg.get('session_event') is not None:
+            ret['channel_data']['session_event'] = msg['session_event']
         return ret
 
     def _message_from_api(self, msg):
@@ -177,6 +178,8 @@ class Channel(object):
         channel_data = msg.get('channel_data', {})
         if channel_data.get('continue_session') is not None:
             ret['continue_session'] = channel_data.pop('continue_session')
+        if channel_data.get('session_event') is not None:
+            ret['session_event'] = channel_data.pop('session_event')
         ret['helper_metadata'] = channel_data
         return ret
 

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -164,8 +164,6 @@ class Channel(object):
         ret['content'] = msg['content']
         ret['session_event'] = msg['session_event']
         ret['channel_data'] = msg['helper_metadata']
-        if not ret['channel_data']:
-            ret['channel_data'] = {}
         if msg.get('continue_session'):
             ret['channel_data']['continue_session'] = msg['continue_session']
         return ret

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -156,8 +156,7 @@ class Channel(object):
     @inlineCallbacks
     def send_message(self, amq_client, to_addr, content, **kw):
         message = TransportUserMessage.send(
-            to_addr=to_addr, content=content, 
-            transport_name=self.id) 
+            to_addr=to_addr, content=content, transport_name=self.id)
         queue = '%s.outbound' % self.id
         msg = yield amq_client.publish_message(message, routing_key=queue)
         ret = {}

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -145,3 +145,8 @@ class Channel(object):
         # TODO: Implement channel status
         status['status'] = {}
         return status
+
+    def send_message(self, amq_client, id, to_addr, content, **kw):
+        message = TransportUserMessage(to_addr, content, **kw)
+        queue = '%s.outbound' % id
+        return amq_client.publish_message(message, routing_key=queue)

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -164,7 +164,7 @@ class Channel(object):
         ret['content'] = msg['content']
         ret['session_event'] = msg['session_event']
         ret['channel_data'] = msg['helper_metadata']
-        if msg.get('continue_session'):
+        if msg.get('continue_session') is not None:
             ret['channel_data']['continue_session'] = msg['continue_session']
         return ret
 

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -82,6 +82,7 @@ class Channel(object):
             workercreator = WorkerCreator(self.options)
             config = self._convert_unicode(self._properties['config'])
             config['transport_name'] = self.id
+            config['worker_name'] = self.id
             transport_worker = workercreator.create_worker(
                 class_name, config)
         transport_worker.setName(self.id)

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -81,6 +81,7 @@ class Channel(object):
         if transport_worker is None:
             workercreator = WorkerCreator(self.options)
             config = self._convert_unicode(self._properties['config'])
+            config['transport_name'] = self.id
             transport_worker = workercreator.create_worker(
                 class_name, config)
         transport_worker.setName(self.id)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -142,3 +142,8 @@ class JunebugTestBase(TestCase):
 
     def _unpatch_worker_creation(self):
         Channel.start = self._original_channel_start
+
+    def get_dispatched_messages(self, queue):
+        amqp_client = self.api.amqp_factory.get_client()
+        return amqp_client.broker.get_messages(
+            'vumi', queue)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -17,6 +17,8 @@ from junebug.service import JunebugService
 
 
 class FakeAmqpClient(JunebugAMQClient):
+    '''Amqp client, base upon the real JunebugAMQClient, that uses a
+    FakeAMQPBroker instead of a real broker'''
     def __init__(self, spec):
         super(FakeAmqpClient, self).__init__(TwistedDelegate(), '', spec)
         self.broker = FakeAMQPBroker()
@@ -112,6 +114,7 @@ class JunebugTestBase(TestCase):
         self.url = "http://%s:%s" % (addr.host, addr.port)
 
     def get_message_sender(self):
+        '''Creates a new MessageSender object, with a fake amqp client'''
         message_sender = MessageSender('amqp-spec-0-8.xml', None)
         spec = get_spec(vumi_resource_path('amqp-spec-0-8.xml'))
         client = FakeAmqpClient(spec)
@@ -141,6 +144,9 @@ class JunebugTestBase(TestCase):
         Channel.start = self._original_channel_start
 
     def get_dispatched_messages(self, queue):
+        '''Gets all messages that have been dispatched to the amqp broker.
+        Should only be called after start_server, as it looks in the api for
+        the amqp client'''
         amqp_client = self.api.message_sender.client
         return amqp_client.broker.get_messages(
             'vumi', queue)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -7,7 +7,7 @@ from twisted.web.server import Site
 from txamqp.client import TwistedDelegate
 from vumi.utils import vumi_resource_path
 from vumi.service import get_spec
-from vumi.tests.fake_amqp import FakeAMQPBroker, FakeAMQClient, FakeAMQPChannel
+from vumi.tests.fake_amqp import FakeAMQPBroker, FakeAMQPChannel
 from vumi.tests.helpers import PersistenceHelper, WorkerHelper
 
 from junebug import JunebugApi

--- a/junebug/tests/test_amqp.py
+++ b/junebug/tests/test_amqp.py
@@ -13,6 +13,8 @@ class TestJunebugApi(JunebugTestBase):
         self.message_sender = self.api.message_sender
 
     def test_amqp_factory_create_client(self):
+        '''The amqp factory should create an amqp client with the given
+        parameters and of type JunebugAMQClient'''
         factory = AmqpFactory('amqp-spec-0-8.xml', {
             'vhost': '/'}, None, None)
         client = factory.buildProtocol('localhost')
@@ -21,6 +23,8 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_message_sender_send_message(self):
+        '''The message sender should add a message to the correct queue when
+        send_message is called'''
         msg = TransportUserMessage.send(
             to_addr='+1234', content='test', transport_name='testtransport')
         yield self.message_sender.send_message(
@@ -30,6 +34,8 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_message_sender_send_multiple_messages(self):
+        '''The message sender should send all messages to their correct queues
+        when send_message is called multiple times'''
         msg1 = TransportUserMessage.send(
             to_addr='+1234', content='test1', transport_name='testtransport')
         yield self.message_sender.send_message(
@@ -44,6 +50,8 @@ class TestJunebugApi(JunebugTestBase):
         self.assertEqual(rec_msg2, msg2)
 
     def test_message_sender_send_message_no_connection(self):
+        '''The message sender should raise an error when there is no
+        connection to send the message over'''
         self.message_sender.client = None
         msg = TransportUserMessage.send(
             to_addr='+1234', content='test', transport_name='testtransport')
@@ -54,6 +62,8 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_message_sender_bad_routing_key(self):
+        '''If the routing key is invalid, the message sender should raise an
+        error'''
         msg = TransportUserMessage.send(
             to_addr='+1234', content='test', transport_name='testtransport')
         err = yield self.assertFailure(

--- a/junebug/tests/test_amqp.py
+++ b/junebug/tests/test_amqp.py
@@ -1,0 +1,20 @@
+from junebug.amqp import AmqpFactory, JunebugAMQClient
+from junebug.tests.helpers import JunebugTestBase
+from twisted.internet.defer import inlineCallbacks
+from vumi.tests.fake_amqp import FakeAMQClient
+
+
+class TestJunebugApi(JunebugTestBase):
+    @inlineCallbacks
+    def test_amqp_factory_create_client(self):
+        factory = AmqpFactory('amqp-spec-0-8.xml', {
+            'vhost': '/'})
+        client1 = factory.buildProtocol('localhost')
+        self.assertTrue(isinstance(client1, JunebugAMQClient))
+        self.assertEqual(client1.vhost, '/')
+
+        factory.amqp_client_d.callback(None)
+        factory.amqp_client = client1
+        client2 = yield factory.get_client()
+        self.assertEqual(client1, client2)
+

--- a/junebug/tests/test_amqp.py
+++ b/junebug/tests/test_amqp.py
@@ -6,7 +6,7 @@ from junebug.amqp import (
 from junebug.tests.helpers import JunebugTestBase
 
 
-class TestJunebugApi(JunebugTestBase):
+class TestMessageSender(JunebugTestBase):
     @inlineCallbacks
     def setUp(self):
         yield self.start_server()

--- a/junebug/tests/test_amqp.py
+++ b/junebug/tests/test_amqp.py
@@ -3,7 +3,7 @@ from vumi.message import TransportUserMessage
 
 from junebug.amqp import (
     AmqpConnectionError, AmqpFactory, JunebugAMQClient, RoutingKeyError)
-from junebug.tests.helpers import FakeAmqpClient, JunebugTestBase
+from junebug.tests.helpers import JunebugTestBase
 
 
 class TestJunebugApi(JunebugTestBase):

--- a/junebug/tests/test_amqp.py
+++ b/junebug/tests/test_amqp.py
@@ -1,20 +1,62 @@
-from junebug.amqp import AmqpFactory, JunebugAMQClient
-from junebug.tests.helpers import JunebugTestBase
 from twisted.internet.defer import inlineCallbacks
-from vumi.tests.fake_amqp import FakeAMQClient
+from vumi.message import TransportUserMessage
+
+from junebug.amqp import (
+    AmqpConnectionError, AmqpFactory, JunebugAMQClient, RoutingKeyError)
+from junebug.tests.helpers import FakeAmqpClient, JunebugTestBase
 
 
 class TestJunebugApi(JunebugTestBase):
     @inlineCallbacks
+    def setUp(self):
+        yield self.start_server()
+        self.message_sender = self.api.message_sender
+
     def test_amqp_factory_create_client(self):
         factory = AmqpFactory('amqp-spec-0-8.xml', {
-            'vhost': '/'})
-        client1 = factory.buildProtocol('localhost')
-        self.assertTrue(isinstance(client1, JunebugAMQClient))
-        self.assertEqual(client1.vhost, '/')
+            'vhost': '/'}, None, None)
+        client = factory.buildProtocol('localhost')
+        self.assertTrue(isinstance(client, JunebugAMQClient))
+        self.assertEqual(client.vhost, '/')
 
-        factory.amqp_client_d.callback(None)
-        factory.amqp_client = client1
-        client2 = yield factory.get_client()
-        self.assertEqual(client1, client2)
+    @inlineCallbacks
+    def test_message_sender_send_message(self):
+        msg = TransportUserMessage.send(
+            to_addr='+1234', content='test', transport_name='testtransport')
+        yield self.message_sender.send_message(
+            msg, routing_key='testtransport')
+        [rec_msg] = self.get_dispatched_messages('testtransport')
+        self.assertEqual(rec_msg, msg)
 
+    @inlineCallbacks
+    def test_message_sender_send_multiple_messages(self):
+        msg1 = TransportUserMessage.send(
+            to_addr='+1234', content='test1', transport_name='testtransport')
+        yield self.message_sender.send_message(
+            msg1, routing_key='testtransport')
+        msg2 = TransportUserMessage.send(
+            to_addr='+1234', content='test2', transport_name='testtransport')
+        yield self.message_sender.send_message(
+            msg2, routing_key='testtransport')
+
+        [rec_msg1, rec_msg2] = self.get_dispatched_messages('testtransport')
+        self.assertEqual(rec_msg1, msg1)
+        self.assertEqual(rec_msg2, msg2)
+
+    def test_message_sender_send_message_no_connection(self):
+        self.message_sender.client = None
+        msg = TransportUserMessage.send(
+            to_addr='+1234', content='test', transport_name='testtransport')
+        err = self.assertRaises(
+            AmqpConnectionError, self.message_sender.send_message, msg,
+            routing_key='testtransport')
+        self.assertTrue('Message not sent' in str(err))
+
+    @inlineCallbacks
+    def test_message_sender_bad_routing_key(self):
+        msg = TransportUserMessage.send(
+            to_addr='+1234', content='test', transport_name='testtransport')
+        err = yield self.assertFailure(
+            self.message_sender.send_message(msg, routing_key='Foo'),
+            RoutingKeyError)
+        self.assertTrue('Foo' in str(err))

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -282,7 +282,6 @@ class TestJunebugApi(JunebugTestBase):
                 'in_reply_to': None,
                 'helper_metadata': {},
                 'content': 'foo',
-                'transport_type': 'telnet',
                 'session_event': None,
             }, ignore=['timestamp', 'message_id']) 
 

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -272,7 +272,7 @@ class TestJunebugApi(JunebugTestBase):
             redis, {}, self.default_channel_config, 'test-channel')
         yield channel.save()
         yield channel.start(self.service)
-        resp = yield self.post('/channels/test-channel/messages', {
+        resp = yield self.post('/channels/test-channel/messages/', {
             'to': '+1234', 'content': 'foo', 'from': None})
         yield self.assert_response(
             resp, http.OK, 'message sent', {
@@ -286,9 +286,7 @@ class TestJunebugApi(JunebugTestBase):
                 'session_event': None,
             }, ignore=['timestamp', 'message_id']) 
 
-        amqp_client = self.api.amqp_factory.get_client()
-        [message] = yield amqp_client.broker.get_messages(
-            'vumi', 'test-channel.outbound')
+        [message] = self.get_dispatched_messages('test-channel.outbound')
         message_id = (yield resp.json())['result']['message_id']
         self.assertEqual(message['message_id'], message_id)
 

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -304,6 +304,21 @@ class TestJunebugApi(JunebugTestBase):
             })
 
     @inlineCallbacks
+    def test_send_message_additional_properties(self):
+        '''Additional properties should result in an error being returned.'''
+        resp = yield self.post(
+            '/channels/foo-bar/messages/', {
+                'from': None, 'content': None, 'to': '', 'foo':'bar'})
+        yield self.assert_response(
+            resp, http.BAD_REQUEST, 'api usage error', {
+                'errors': [{
+                    'message': "Additional properties are not allowed (u'foo' "
+                    "was unexpected)",
+                    'type': 'invalid_body',
+                }]
+            })
+
+    @inlineCallbacks
     def test_send_message_both_to_and_reply_to(self):
         resp = yield self.post('/channels/foo-bar/messages/', {
             'from': None,

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -283,7 +283,7 @@ class TestJunebugApi(JunebugTestBase):
                 'helper_metadata': {},
                 'content': 'foo',
                 'session_event': None,
-            }, ignore=['timestamp', 'message_id']) 
+            }, ignore=['timestamp', 'message_id'])
 
         [message] = self.get_dispatched_messages('test-channel.outbound')
         message_id = (yield resp.json())['result']['message_id']

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -267,6 +267,8 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_send_message(self):
+        '''Sending a message should place the message on the queue for the
+        channel'''
         redis = yield self.get_redis()
         channel = Channel(
             redis, {}, self.default_channel_config, 'test-channel')

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -256,7 +256,7 @@ class TestJunebugApi(JunebugTestBase):
     @inlineCallbacks
     def test_send_message_invalid_channel(self):
         resp = yield self.post('/channels/foo-bar/messages/', {
-            'to': '+1234', 'from': ''})
+            'to': '+1234', 'from': '', 'content': None})
         yield self.assert_response(
             resp, http.NOT_FOUND, 'channel not found', {
                 'errors': [{
@@ -278,11 +278,11 @@ class TestJunebugApi(JunebugTestBase):
             'to': '+1234', 'content': 'foo', 'from': None})
         yield self.assert_response(
             resp, http.OK, 'message sent', {
-                'to_addr': '+1234',
-                'transport_name': 'test-channel',
-                'from_addr': None,
-                'in_reply_to': None,
-                'helper_metadata': {},
+                'to': '+1234',
+                'channel_id': 'test-channel',
+                'from': None,
+                'reply_to': None,
+                'channel_data': {},
                 'content': 'foo',
                 'session_event': None,
             }, ignore=['timestamp', 'message_id'])
@@ -293,7 +293,8 @@ class TestJunebugApi(JunebugTestBase):
 
     @inlineCallbacks
     def test_send_message_no_to_or_reply_to(self):
-        resp = yield self.post('/channels/foo-bar/messages/', {'from': None})
+        resp = yield self.post(
+            '/channels/foo-bar/messages/', {'from': None, 'content': None})
         yield self.assert_response(
             resp, http.BAD_REQUEST, 'api usage error', {
                 'errors': [{
@@ -308,6 +309,7 @@ class TestJunebugApi(JunebugTestBase):
             'from': None,
             'to': '+1234',
             'reply_to': '2e8u9ua8',
+            'content': None,
         })
         yield self.assert_response(
             resp, http.BAD_REQUEST, 'api usage error', {

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -284,7 +284,6 @@ class TestJunebugApi(JunebugTestBase):
                 'reply_to': None,
                 'channel_data': {},
                 'content': 'foo',
-                'session_event': None,
             }, ignore=['timestamp', 'message_id'])
 
         [message] = self.get_dispatched_messages('test-channel.outbound')

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -308,7 +308,7 @@ class TestJunebugApi(JunebugTestBase):
         '''Additional properties should result in an error being returned.'''
         resp = yield self.post(
             '/channels/foo-bar/messages/', {
-                'from': None, 'content': None, 'to': '', 'foo':'bar'})
+                'from': None, 'content': None, 'to': '', 'foo': 'bar'})
         yield self.assert_response(
             resp, http.BAD_REQUEST, 'api usage error', {
                 'errors': [{

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -207,4 +207,3 @@ class TestChannel(JunebugTestBase):
         self.assertEqual(msg.get('helper_metadata'), {'voice': {}})
         self.assertEqual(msg.get('from_addr'), '+1234')
         self.assertEqual(msg.get('content'), None)
-

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -14,10 +14,7 @@ class TestChannel(JunebugTestBase):
         self.patch_logger()
 
         self.redis = yield self.get_redis()
-        self.service = JunebugService(
-            'localhost', 0, self.redis._config, {})
-        yield self.service.startService()
-        self.addCleanup(self.service.stopService)
+        yield self.start_server()
 
     @inlineCallbacks
     def test_save_channel(self):
@@ -148,3 +145,8 @@ class TestChannel(JunebugTestBase):
             self.assertTrue(isinstance(value, str))
 
         self.assertTrue(isinstance(channel._convert_unicode(1), int))
+
+    @inlineCallbacks
+    def test_send_message(self):
+        channel = yield self.create_channel(
+            self.service, self.redis, TelnetServerTransport, id='channel-id')

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -23,6 +23,7 @@ class TestChannel(JunebugTestBase):
         properties = yield self.redis.get('%s:properties' % channel.id)
         expected = deepcopy(self.default_channel_config)
         expected['config']['worker_name'] = channel.id
+        expected['config']['transport_name'] = channel.id
         self.assertEqual(json.loads(properties), expected)
 
     @inlineCallbacks
@@ -32,6 +33,7 @@ class TestChannel(JunebugTestBase):
         properties = yield self.redis.get('%s:properties' % channel.id)
         expected = deepcopy(self.default_channel_config)
         expected['config']['worker_name'] = channel.id
+        expected['config']['transport_name'] = channel.id
         self.assertEqual(json.loads(properties), expected)
 
         yield channel.delete()
@@ -69,6 +71,7 @@ class TestChannel(JunebugTestBase):
             'id': channel.id,
             })
         expected['config']['worker_name'] = channel.id
+        expected['config']['transport_name'] = channel.id
         self.assertEqual(update, expected)
 
     @inlineCallbacks
@@ -107,6 +110,7 @@ class TestChannel(JunebugTestBase):
             'status': {},
             })
         expected['config']['worker_name'] = channel.id
+        expected['config']['transport_name'] = channel.id
         self.assertEqual((yield channel.status()), expected)
 
     @inlineCallbacks

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -4,7 +4,6 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.transports.telnet import TelnetServerTransport
 
 from junebug.channel import Channel, ChannelNotFound, InvalidChannelType
-from junebug.service import JunebugService
 from junebug.tests.helpers import JunebugTestBase
 
 
@@ -156,5 +155,6 @@ class TestChannel(JunebugTestBase):
         self.assertEqual(msg['to_addr'], '+1234')
         self.assertEqual(msg['content'], 'testcontent')
 
-        [dispatched_message] = self.get_dispatched_messages('channel-id.outbound')
+        [dispatched_message] = self.get_dispatched_messages(
+            'channel-id.outbound')
         self.assertEqual(msg['message_id'], dispatched_message['message_id'])

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -147,6 +147,8 @@ class TestChannel(JunebugTestBase):
 
     @inlineCallbacks
     def test_send_message(self):
+        '''The send_message function should place the message on the correct
+        queue'''
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
         msg = yield channel.send_message(

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -149,8 +149,8 @@ class TestChannel(JunebugTestBase):
     def test_send_message(self):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
-        amq_client = self.api.amqp_factory.get_client()
-        msg = yield channel.send_message(amq_client, '+1234', 'testcontent')
+        msg = yield channel.send_message(
+            self.api.message_sender, '+1234', 'testcontent')
         self.assertEqual(msg['transport_name'], 'channel-id')
         self.assertEqual(msg['to_addr'], '+1234')
         self.assertEqual(msg['content'], 'testcontent')

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -187,7 +187,6 @@ class TestChannel(JunebugTestBase):
             'channel_id': 'testtransport',
             'content': None,
             'reply_to': None,
-            'session_event': None,
             })
 
     @inlineCallbacks

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -1,20 +1,28 @@
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
-from vumi.tests.helpers import PersistenceHelper
 
+from junebug import JunebugApi
 from junebug.service import JunebugService
 
 
 class TestJunebugService(TestCase):
-    @inlineCallbacks
     def setUp(self):
-        self.persistencehelper = PersistenceHelper()
-        yield self.persistencehelper.setup()
-        self.redis = yield self.persistencehelper.get_redis_manager()
+        self.old_setup = JunebugApi.setup
+        self.old_teardown = JunebugApi.teardown
+
+        def do_nothing(self):
+            pass
+
+        JunebugApi.setup = do_nothing
+        JunebugApi.teardown = do_nothing
+
+    def tearDown(self):
+        JunebugApi.setup = self.old_setup
+        JunebugApi.teardown = self.old_teardown
 
     @inlineCallbacks
     def test_start_service(self):
-        service = JunebugService('localhost', 0, self.redis._config, {})
+        service = JunebugService('localhost', 0, {}, {})
 
         yield service.startService()
         server = service._port

--- a/junebug/utils.py
+++ b/junebug/utils.py
@@ -2,6 +2,7 @@ import json
 
 from twisted.web import http
 from functools import wraps
+from vumi.message import JSONMessageEncoder
 
 
 def response(req, description, data, code=http.OK):
@@ -13,7 +14,7 @@ def response(req, description, data, code=http.OK):
         'code': http.RESPONSES[code],
         'description': description,
         'result': data,
-    })
+    }, cls=JSONMessageEncoder)
 
 
 def json_body(fn):


### PR DESCRIPTION
Add the ability to send a message across a channel by posting to `/channels/channel-id/messages`. Adds the message to the correct rabbitmq queue for the specified channel-id.