### PR TITLE
Make send_message a class method

### DIFF
--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -152,8 +152,8 @@ class TestChannel(JunebugTestBase):
         queue'''
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
-        msg = yield channel.send_message(
-            self.api.message_sender, {
+        msg = yield Channel.send_message(
+            'channel-id', self.api.message_sender, {
                 'from': '+1234',
                 'content': 'testcontent',
             })
@@ -193,14 +193,15 @@ class TestChannel(JunebugTestBase):
     def test_message_from_api(self):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
-        msg = channel._message_from_api({
-            'from': '+1234',
-            'content': None,
-            'channel_data': {
-                'continue_session': True,
-                'voice': {},
-                },
-            })
+        msg = Channel._message_from_api(
+            'channel-id', {
+                'from': '+1234',
+                'content': None,
+                'channel_data': {
+                    'continue_session': True,
+                    'voice': {},
+                    },
+                })
         msg = TransportUserMessage.send(**msg)
         self.assertEqual(msg.get('continue_session'), True)
         self.assertEqual(msg.get('helper_metadata'), {'voice': {}})


### PR DESCRIPTION
Currently, whenever a channel is created, it fetches its properties from redis. For some things (mainly sending messages), this isn't needed, so we should fetch properties in a more "on demand" way, caching it on the channel object.