### PR TITLE
Get config from file

### DIFF
--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import argparse
 import logging
 import logging.handlers
@@ -8,6 +9,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.python import log
 
 from junebug.service import JunebugService
+from junebug.config import JunebugConfig
 
 
 def parse_arguments(args):
@@ -19,52 +21,47 @@ def parse_arguments(args):
             'RESTful HTTP interface'))
 
     parser.add_argument(
-        '--interface', '-i', dest='interface', default='localhost', type=str,
+        '--config', '-c', dest='config_filename', type=str,
+        help='Path to config file. Optional. Command line options override '
+             'config options')
+    parser.add_argument(
+        '--interface', '-i', dest='interface', type=str,
         help='The interface to expose the API on. Defaults to "localhost"')
     parser.add_argument(
         '--port', '-p', dest='port', default=8080, type=int,
         help='The port to expose the API on, defaults to "8080"')
     parser.add_argument(
-        '--log-file', '-l', dest='logfile', default=None, type=str,
+        '--log-file', '-l', dest='logfile', type=str,
         help='The file to log to. Defaults to not logging to a file')
     parser.add_argument(
-        '--redis-host', '-redish', dest='redis_host', default='localhost',
-        type=str,
+        '--redis-host', '-redish', dest='redis_host', type=str,
         help='The hostname of the redis instance. Defaults to "localhost"')
     parser.add_argument(
-        '--redis-port', '-redisp', dest='redis_port', default=6379,
-        type=int,
+        '--redis-port', '-redisp', dest='redis_port', type=int,
         help='The port of the redis instance. Defaults to "6379"')
     parser.add_argument(
-        '--redis-db', '-redisdb', dest='redis_db', default=0,
-        type=int,
+        '--redis-db', '-redisdb', dest='redis_db', type=int,
         help='The database to use for the redis instance. Defaults to "0"')
     parser.add_argument(
-        '--redis-password', '-redispass', dest='redis_pass', default=None,
-        type=str,
+        '--redis-password', '-redispass', dest='redis_pass', type=str,
         help='The password to use for the redis instance. Defaults to "None"')
     parser.add_argument(
-        '--amqp-host', '-amqph', dest='amqp_host', default='127.0.0.1',
-        type=str,
+        '--amqp-host', '-amqph', dest='amqp_host', type=str,
         help='The hostname of the amqp endpoint. Defaults to "127.0.0.1"')
     parser.add_argument(
-        '--amqp-vhost', '-amqpvh', dest='amqp_vhost', default='/',
-        type=str,
+        '--amqp-vhost', '-amqpvh', dest='amqp_vhost', type=str,
         help='The amqp vhost. Defaults to "/"')
     parser.add_argument(
-        '--amqp-port', '-amqpp', dest='amqp_port', default=5672,
-        type=int,
+        '--amqp-port', '-amqpp', dest='amqp_port', type=int,
         help='The port of the amqp endpoint. Defaults to "5672"')
     parser.add_argument(
-        '--amqp-user', '-amqpu', dest='amqp_user', default='guest',
-        type=str,
+        '--amqp-user', '-amqpu', dest='amqp_user', type=str,
         help='The username to use for the amqp auth. Defaults to "guest"')
     parser.add_argument(
-        '--amqp-password', '-amqppass', dest='amqp_pass', default='guest',
-        type=str,
+        '--amqp-password', '-amqppass', dest='amqp_pass', type=str,
         help='The password to use for the amqp auth. Defaults to "guest"')
 
-    return parser.parse_args(args)
+    return config_from_args(vars(parser.parse_args(args)))
 
 
 def logging_setup(filename):
@@ -89,32 +86,71 @@ def logging_setup(filename):
 
 
 @inlineCallbacks
-def start_server(interface, port, redis_config, amqp_config):
+def start_server(config):
     '''Starts a new Junebug HTTP API server on the specified resource and
     port'''
-    service = JunebugService(interface, port, redis_config, amqp_config)
+    service = JunebugService(config)
     yield service.startService()
     returnValue(service)
 
 
 def main():
-    args = parse_arguments(sys.argv[1:])
-    logging_setup(args.logfile)
-    redis_config = {
-        'host': args.redis_host,
-        'port': args.redis_port,
-        'db': args.redis_db,
-        'password': args.redis_pass,
-    }
-    amqp_config = {
-        'hostname': args.amqp_host,
-        'vhost': args.amqp_vhost,
-        'port': args.amqp_port,
-        'username': args.amqp_user,
-        'password': args.amqp_pass,
-    }
-    start_server(args.interface, args.port, redis_config, amqp_config)
+    config = parse_arguments(sys.argv[1:])
+    logging_setup(config.logfile)
+    start_server(config)
     reactor.run()
+
+
+def config_from_args(args):
+    args = omit_nones(args)
+    config = {}
+    config['redis_config'] = parse_redis(config.get('redis_config', {}), args)
+    config['amqp_config'] = parse_amqp(config.get('amqp_config', {}), args)
+    return JunebugConfig(conjoin(args, config))
+
+
+def parse_redis(config, args):
+    config = conjoin(deepcopy(JunebugConfig.redis_config.default), config)
+
+    overrides(config, args, {
+        'host': 'redis_host',
+        'port': 'redis_port',
+        'db': 'redis_db',
+        'password': 'redis_pass',
+    })
+
+    return config
+
+
+def parse_amqp(config, args):
+    config = conjoin(deepcopy(JunebugConfig.amqp_config.default), config)
+
+    overrides(config, args, {
+        'hostname': 'amqp_host',
+        'vhost': 'amqp_vhost',
+        'port': 'amqp_port',
+        'username': 'amqp_user',
+        'password': 'amqp_pass',
+    })
+
+    return config
+
+
+def omit_nones(d):
+    return dict((k, v) for k, v in d.iteritems() if v is not None)
+
+
+def conjoin(a, b):
+    result = {}
+    result.update(a)
+    result.update(b)
+    return result
+
+
+def overrides(target, source, mappings):
+    for to_key, from_key in mappings.iteritems():
+        if from_key in source:
+            target[to_key] = source[from_key]
 
 
 if __name__ == '__main__':

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -105,13 +105,13 @@ def main():
 def config_from_args(args):
     args = omit_nones(args)
     config = load_config(args.pop('config_filename', None))
-    config['redis_config'] = parse_redis(config.get('redis_config', {}), args)
-    config['amqp_config'] = parse_amqp(config.get('amqp_config', {}), args)
+    config['redis'] = parse_redis(config.get('redis', {}), args)
+    config['amqp'] = parse_amqp(config.get('amqp', {}), args)
     return JunebugConfig(conjoin(config, args))
 
 
 def parse_redis(config, args):
-    config = conjoin(deepcopy(JunebugConfig.redis_config.default), config)
+    config = conjoin(deepcopy(JunebugConfig.redis.default), config)
 
     overrides(config, args, {
         'host': 'redis_host',
@@ -124,7 +124,7 @@ def parse_redis(config, args):
 
 
 def parse_amqp(config, args):
-    config = conjoin(deepcopy(JunebugConfig.amqp_config.default), config)
+    config = conjoin(deepcopy(JunebugConfig.amqp.default), config)
 
     overrides(config, args, {
         'hostname': 'amqp_host',

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -83,7 +83,7 @@ def logging_setup(filename):
     # Set up file logger
     if filename:
         handler = logging.handlers.RotatingFileHandler(
-            filename, maxBytes=1024*1024, backupCount=5)
+            filename, maxBytes=1024 * 1024, backupCount=5)
         handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
         logging.getLogger().addHandler(handler)
 

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -1,0 +1,36 @@
+from confmodel import Config
+from confmodel.fields import ConfigText, ConfigInt, ConfigDict
+
+
+class JunebugConfig(Config):
+    interface = ConfigText(
+        "Interface to expose the API on",
+        default='localhost')
+
+    port = ConfigInt(
+        "Port to expose the API on",
+        default=8080)
+
+    logfile = ConfigText(
+        "File to log to or `None` for no logging",
+        default=None)
+
+    redis_config = ConfigDict(
+        "Config to use for redis connection",
+        default={
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'password': None
+        })
+
+    amqp_config = ConfigDict(
+        "Config to use for amqp connection",
+        default={
+            'host': 'localhost',
+            'vhost': '/',
+            'port': 5672,
+            'db': 0,
+            'username': 'guest',
+            'password': 'guest'
+        })

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -15,7 +15,7 @@ class JunebugConfig(Config):
         "File to log to or `None` for no logging",
         default=None)
 
-    redis_config = ConfigDict(
+    redis = ConfigDict(
         "Config to use for redis connection",
         default={
             'host': 'localhost',
@@ -24,7 +24,7 @@ class JunebugConfig(Config):
             'password': None
         })
 
-    amqp_config = ConfigDict(
+    amqp = ConfigDict(
         "Config to use for amqp connection",
         default={
             'hostname': '127.0.0.1',

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -27,7 +27,7 @@ class JunebugConfig(Config):
     amqp_config = ConfigDict(
         "Config to use for amqp connection",
         default={
-            'host': 'localhost',
+            'hostname': '127.0.0.1',
             'vhost': '/',
             'port': 5672,
             'db': 0,

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -10,12 +10,9 @@ from junebug import JunebugApi
 class JunebugService(MultiService, object):
     '''Base service that runs the HTTP API, and contains transports as child
     services'''
-    def __init__(self, interface, port, redis_config, amqp_config):
+    def __init__(self, config):
         super(JunebugService, self).__init__()
-        self.interface = interface
-        self.port = port
-        self.redis_config = redis_config
-        self.amqp_config = amqp_config
+        self.config = config
 
     @inlineCallbacks
     def startService(self):
@@ -23,12 +20,14 @@ class JunebugService(MultiService, object):
         is listening on'''
         super(JunebugService, self).startService()
         self.api = JunebugApi(
-            self, self.redis_config, self.amqp_config)
+            self, self.config.redis_config, self.config.amqp_config)
         yield self.api.setup()
         self._port = reactor.listenTCP(
-            self.port, Site(self.api.app.resource()),
-            interface=self.interface)
-        log.msg('Junebug is listening on %s:%s' % (self.interface, self.port))
+            self.config.port, Site(self.api.app.resource()),
+            interface=self.config.interface)
+        log.msg(
+            'Junebug is listening on %s:%s' %
+            (self.config.interface, self.config.port))
 
     @inlineCallbacks
     def stopService(self):

--- a/junebug/service.py
+++ b/junebug/service.py
@@ -19,8 +19,7 @@ class JunebugService(MultiService, object):
         '''Starts the HTTP server, and returns the port object that the server
         is listening on'''
         super(JunebugService, self).startService()
-        self.api = JunebugApi(
-            self, self.config.redis_config, self.config.amqp_config)
+        self.api = JunebugApi(self, self.config.redis, self.config.amqp)
         yield self.api.setup()
         self._port = reactor.listenTCP(
             self.config.port, Site(self.api.app.resource()),

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -103,8 +103,8 @@ class JunebugTestBase(TestCase):
         self.service = JunebugService(JunebugConfig({
             'host': '127.0.0.1',
             'port': 0,
-            'redis_config': redis._config,
-            'amqp_config': {
+            'redis': redis._config,
+            'amqp': {
                 'hostname': '',
                 'port': ''
             }

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -14,6 +14,7 @@ from junebug import JunebugApi
 from junebug.amqp import JunebugAMQClient, MessageSender
 from junebug.channel import Channel
 from junebug.service import JunebugService
+from junebug.config import JunebugConfig
 
 
 class FakeAmqpClient(JunebugAMQClient):
@@ -99,7 +100,15 @@ class JunebugTestBase(TestCase):
         '''Starts a junebug server. Stores the service to "self.service", and
         the url at "self.url"'''
         redis = yield self.get_redis()
-        self.service = JunebugService('127.0.0.1', 0, redis._config, {})
+        self.service = JunebugService(JunebugConfig({
+            'host': '127.0.0.1',
+            'port': 0,
+            'redis_config': redis._config,
+            'amqp_config': {
+                'hostname': '',
+                'port': ''
+            }
+        }))
         self.api = JunebugApi(
             self.service, redis._config, {'hostname': '', 'port': ''})
         self.api.redis = redis

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -179,8 +179,19 @@ class TestCommandLine(JunebugTestBase):
                 'interface': 'lolcathost',
                 'port': 1337,
                 'logfile': 'stuff.log',
-                'redis': {'host': 'rawrcathost'},
-                'amqp': {'hostname': 'xorcathost'},
+                'redis': {
+                    'host': 'rawrcathost',
+                    'port': 3223,
+                    'db': 9000,
+                    'password': 't00r'
+                },
+                'amqp': {
+                    'hostname': 'xorcathost',
+                    'port': 2332,
+                    'vhost': '/root',
+                    'username': 'admin',
+                    'password': 'nimda',
+                },
             }
         })
 
@@ -189,14 +200,28 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.port, 1337)
         self.assertEqual(config.logfile, 'stuff.log')
         self.assertEqual(config.redis['host'], 'rawrcathost')
+        self.assertEqual(config.redis['port'], 3223)
+        self.assertEqual(config.redis['db'], 9000)
+        self.assertEqual(config.redis['password'], 't00r')
         self.assertEqual(config.amqp['hostname'], 'xorcathost')
+        self.assertEqual(config.amqp['vhost'], '/root')
+        self.assertEqual(config.amqp['port'], 2332)
+        self.assertEqual(config.amqp['username'], 'admin')
+        self.assertEqual(config.amqp['password'], 'nimda')
 
         config = parse_arguments(['-c', '/foo/bar.yaml'])
         self.assertEqual(config.interface, 'lolcathost')
         self.assertEqual(config.port, 1337)
         self.assertEqual(config.logfile, 'stuff.log')
         self.assertEqual(config.redis['host'], 'rawrcathost')
+        self.assertEqual(config.redis['port'], 3223)
+        self.assertEqual(config.redis['db'], 9000)
+        self.assertEqual(config.redis['password'], 't00r')
         self.assertEqual(config.amqp['hostname'], 'xorcathost')
+        self.assertEqual(config.amqp['vhost'], '/root')
+        self.assertEqual(config.amqp['port'], 2332)
+        self.assertEqual(config.amqp['username'], 'admin')
+        self.assertEqual(config.amqp['password'], 'nimda')
 
     def test_config_file_overriding(self):
         '''Config file options are overriden by their corresponding command
@@ -206,8 +231,19 @@ class TestCommandLine(JunebugTestBase):
                 'interface': 'lolcathost',
                 'port': 1337,
                 'logfile': 'stuff.log',
-                'redis': {'host': 'rawrcathost'},
-                'amqp': {'hostname': 'xorcathost'},
+                'redis': {
+                    'host': 'rawrcathost',
+                    'port': 3223,
+                    'db': 9000,
+                    'password': 't00r'
+                },
+                'amqp': {
+                    'hostname': 'xorcathost',
+                    'port': 2332,
+                    'vhost': '/root',
+                    'username': 'admin',
+                    'password': 'nimda',
+                },
             }
         })
 
@@ -217,14 +253,28 @@ class TestCommandLine(JunebugTestBase):
             '-p', '1620',
             '-l', 'logs.log',
             '-redish', 'bluish',
-            '-amqph', 'hpqma',
+            '-redisp', '2112',
+            '-redisdb', '23',
+            '-redispass', 'cat',
+            '-amqph', 'soup',
+            '-amqpp', '2112',
+            '-amqpvh', '/soho',
+            '-amqpu', 'koenji',
+            '-amqppass', 'kodama',
         ])
 
         self.assertEqual(config.interface, 'zuulcathost')
         self.assertEqual(config.port, 1620)
         self.assertEqual(config.logfile, 'logs.log')
         self.assertEqual(config.redis['host'], 'bluish')
-        self.assertEqual(config.amqp['hostname'], 'hpqma')
+        self.assertEqual(config.redis['port'], 2112)
+        self.assertEqual(config.redis['db'], 23)
+        self.assertEqual(config.redis['password'], 'cat')
+        self.assertEqual(config.amqp['hostname'], 'soup')
+        self.assertEqual(config.amqp['vhost'], '/soho')
+        self.assertEqual(config.amqp['port'], 2112)
+        self.assertEqual(config.amqp['username'], 'koenji')
+        self.assertEqual(config.amqp['password'], 'kodama')
 
     def test_logging_setup(self):
         '''If filename is None, just a stdout logger is created, if filename

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -5,6 +5,7 @@ from twisted.internet.defer import inlineCallbacks
 from junebug import JunebugApi
 from junebug.command_line import parse_arguments, logging_setup, start_server
 from junebug.tests.helpers import JunebugTestBase
+from junebug.config import JunebugConfig
 
 
 class TestCommandLine(JunebugTestBase):
@@ -25,146 +26,146 @@ class TestCommandLine(JunebugTestBase):
     def test_parse_arguments_interface(self):
         '''The interface command line argument can be specified by
         "--interface" and "-i" and has a default value of "localhost"'''
-        args = parse_arguments([])
-        self.assertEqual(args.interface, 'localhost')
+        config = parse_arguments([])
+        self.assertEqual(config.interface, 'localhost')
 
-        args = parse_arguments(['--interface', 'foobar'])
-        self.assertEqual(args.interface, 'foobar')
+        config = parse_arguments(['--interface', 'foobar'])
+        self.assertEqual(config.interface, 'foobar')
 
-        args = parse_arguments(['-i', 'foobar'])
-        self.assertEqual(args.interface, 'foobar')
+        config = parse_arguments(['-i', 'foobar'])
+        self.assertEqual(config.interface, 'foobar')
 
     def test_parse_arguments_port(self):
         '''The port command line argument can be specified by
         "--port" or "-p" and has a default value of 8080'''
-        args = parse_arguments([])
-        self.assertEqual(args.port, 8080)
+        config = parse_arguments([])
+        self.assertEqual(config.port, 8080)
 
-        args = parse_arguments(['--port', '80'])
-        self.assertEqual(args.port, 80)
+        config = parse_arguments(['--port', '80'])
+        self.assertEqual(config.port, 80)
 
-        args = parse_arguments(['-p', '80'])
-        self.assertEqual(args.port, 80)
+        config = parse_arguments(['-p', '80'])
+        self.assertEqual(config.port, 80)
 
     def test_parse_arguments_log_file(self):
         '''The log file command line argument can be specified by
         "--log-file" or "-l" and has a default value of None'''
-        args = parse_arguments([])
-        self.assertEqual(args.logfile, None)
+        config = parse_arguments([])
+        self.assertEqual(config.logfile, None)
 
-        args = parse_arguments(['--log-file', 'foo.bar'])
-        self.assertEqual(args.logfile, 'foo.bar')
+        config = parse_arguments(['--log-file', 'foo.bar'])
+        self.assertEqual(config.logfile, 'foo.bar')
 
-        args = parse_arguments(['-l', 'foo.bar'])
-        self.assertEqual(args.logfile, 'foo.bar')
+        config = parse_arguments(['-l', 'foo.bar'])
+        self.assertEqual(config.logfile, 'foo.bar')
 
     def test_parse_arguments_redis_host(self):
         '''The redis host command line argument can be specified by
         "--redis-host" or "-redish" and has a default value of "localhost"'''
-        args = parse_arguments([])
-        self.assertEqual(args.redis_host, 'localhost')
+        config = parse_arguments([])
+        self.assertEqual(config.redis_config['host'], 'localhost')
 
-        args = parse_arguments(['--redis-host', 'foo.bar'])
-        self.assertEqual(args.redis_host, 'foo.bar')
+        config = parse_arguments(['--redis-host', 'foo.bar'])
+        self.assertEqual(config.redis_config['host'], 'foo.bar')
 
-        args = parse_arguments(['-redish', 'foo.bar'])
-        self.assertEqual(args.redis_host, 'foo.bar')
+        config = parse_arguments(['-redish', 'foo.bar'])
+        self.assertEqual(config.redis_config['host'], 'foo.bar')
 
-    def test_parse_arguments_redis_port(self):
+    def test_parse_arguments_redis_config_port(self):
         '''The redis port command line argument can be specified by
         "--redis-port" or "-redisp" and has a default value of 6379'''
-        args = parse_arguments([])
-        self.assertEqual(args.redis_port, 6379)
+        config = parse_arguments([])
+        self.assertEqual(config.redis_config['port'], 6379)
 
-        args = parse_arguments(['--redis-port', '80'])
-        self.assertEqual(args.redis_port, 80)
+        config = parse_arguments(['--redis-port', '80'])
+        self.assertEqual(config.redis_config['port'], 80)
 
-        args = parse_arguments(['-redisp', '80'])
-        self.assertEqual(args.redis_port, 80)
+        config = parse_arguments(['-redisp', '80'])
+        self.assertEqual(config.redis_config['port'], 80)
 
     def test_parse_arguments_redis_database(self):
         '''The redis database command line argument can be specified by
         "--redis-db" or "-redisdb" and has a default value of 0'''
-        args = parse_arguments([])
-        self.assertEqual(args.redis_db, 0)
+        config = parse_arguments([])
+        self.assertEqual(config.redis_config['db'], 0)
 
-        args = parse_arguments(['--redis-db', '80'])
-        self.assertEqual(args.redis_db, 80)
+        config = parse_arguments(['--redis-db', '80'])
+        self.assertEqual(config.redis_config['db'], 80)
 
-        args = parse_arguments(['-redisdb', '80'])
-        self.assertEqual(args.redis_db, 80)
+        config = parse_arguments(['-redisdb', '80'])
+        self.assertEqual(config.redis_config['db'], 80)
 
     def test_parse_arguments_redis_password(self):
         '''The redis password command line argument can be specified by
         "--redis-password" or "-redispass" and has a default value of None'''
-        args = parse_arguments([])
-        self.assertEqual(args.redis_pass, None)
+        config = parse_arguments([])
+        self.assertEqual(config.redis_config['password'], None)
 
-        args = parse_arguments(['--redis-password', 'foo.bar'])
-        self.assertEqual(args.redis_pass, 'foo.bar')
+        config = parse_arguments(['--redis-password', 'foo.bar'])
+        self.assertEqual(config.redis_config['password'], 'foo.bar')
 
-        args = parse_arguments(['-redispass', 'foo.bar'])
-        self.assertEqual(args.redis_pass, 'foo.bar')
+        config = parse_arguments(['-redispass', 'foo.bar'])
+        self.assertEqual(config.redis_config['password'], 'foo.bar')
 
     def test_parse_arguments_amqp_host(self):
         '''The amqp host command line argument can be specified by
         "--amqp-host" or "-amqph" and has a default value of "127.0.0.1"'''
-        args = parse_arguments([])
-        self.assertEqual(args.amqp_host, '127.0.0.1')
+        config = parse_arguments([])
+        self.assertEqual(config.amqp_config['hostname'], '127.0.0.1')
 
-        args = parse_arguments(['--amqp-host', 'foo.bar'])
-        self.assertEqual(args.amqp_host, 'foo.bar')
+        config = parse_arguments(['--amqp-host', 'foo.bar'])
+        self.assertEqual(config.amqp_config['hostname'], 'foo.bar')
 
-        args = parse_arguments(['-amqph', 'foo.bar'])
-        self.assertEqual(args.amqp_host, 'foo.bar')
+        config = parse_arguments(['-amqph', 'foo.bar'])
+        self.assertEqual(config.amqp_config['hostname'], 'foo.bar')
 
     def test_parse_arguments_amqp_port(self):
         '''The amqp port command line argument can be specified by
         "--amqp-port" or "-amqpp" and has a default value of 5672'''
-        args = parse_arguments([])
-        self.assertEqual(args.amqp_port, 5672)
+        config = parse_arguments([])
+        self.assertEqual(config.amqp_config['port'], 5672)
 
-        args = parse_arguments(['--amqp-port', '80'])
-        self.assertEqual(args.amqp_port, 80)
+        config = parse_arguments(['--amqp-port', '80'])
+        self.assertEqual(config.amqp_config['port'], 80)
 
-        args = parse_arguments(['-amqpp', '80'])
-        self.assertEqual(args.amqp_port, 80)
+        config = parse_arguments(['-amqpp', '80'])
+        self.assertEqual(config.amqp_config['port'], 80)
 
     def test_parse_arguments_amqp_username(self):
         '''The amqp username command line argument can be specified by
         "--amqp-user" or "-amqpu" and has a default value of "guest"'''
-        args = parse_arguments([])
-        self.assertEqual(args.amqp_user, 'guest')
+        config = parse_arguments([])
+        self.assertEqual(config.amqp_config['username'], 'guest')
 
-        args = parse_arguments(['--amqp-user', 'test'])
-        self.assertEqual(args.amqp_user, 'test')
+        config = parse_arguments(['--amqp-user', 'test'])
+        self.assertEqual(config.amqp_config['username'], 'test')
 
-        args = parse_arguments(['-amqpu', 'test'])
-        self.assertEqual(args.amqp_user, 'test')
+        config = parse_arguments(['-amqpu', 'test'])
+        self.assertEqual(config.amqp_config['username'], 'test')
 
     def test_parse_arguments_amqp_password(self):
         '''The amqp password command line argument can be specified by
         "--amqp-password" or "-amqppass" and has a default value of "guest"'''
-        args = parse_arguments([])
-        self.assertEqual(args.amqp_pass, 'guest')
+        config = parse_arguments([])
+        self.assertEqual(config.amqp_config['password'], 'guest')
 
-        args = parse_arguments(['--amqp-password', 'foo.bar'])
-        self.assertEqual(args.amqp_pass, 'foo.bar')
+        config = parse_arguments(['--amqp-password', 'foo.bar'])
+        self.assertEqual(config.amqp_config['password'], 'foo.bar')
 
-        args = parse_arguments(['-amqppass', 'foo.bar'])
-        self.assertEqual(args.amqp_pass, 'foo.bar')
+        config = parse_arguments(['-amqppass', 'foo.bar'])
+        self.assertEqual(config.amqp_config['password'], 'foo.bar')
 
     def test_parse_arguments_amqp_vhost(self):
         '''The amqp vhost command line argument can be specified by
         "--amqp-vhost" or "-amqpv" and has a default value of "/"'''
-        args = parse_arguments([])
-        self.assertEqual(args.amqp_vhost, '/')
+        config = parse_arguments([])
+        self.assertEqual(config.amqp_config['vhost'], '/')
 
-        args = parse_arguments(['--amqp-vhost', 'foo.bar'])
-        self.assertEqual(args.amqp_vhost, 'foo.bar')
+        config = parse_arguments(['--amqp-vhost', 'foo.bar'])
+        self.assertEqual(config.amqp_config['vhost'], 'foo.bar')
 
-        args = parse_arguments(['-amqpv', 'foo.bar'])
-        self.assertEqual(args.amqp_vhost, 'foo.bar')
+        config = parse_arguments(['-amqpv', 'foo.bar'])
+        self.assertEqual(config.amqp_config['vhost'], 'foo.bar')
 
     def test_logging_setup(self):
         '''If filename is None, just a stdout logger is created, if filename
@@ -193,10 +194,14 @@ class TestCommandLine(JunebugTestBase):
         '''Starting the server should listen on the specified interface and
         port'''
         redis = yield self.get_redis()
-        service = yield start_server('localhost', 0, redis._config, {
-            'hostname': 'localhost',
+
+        config = JunebugConfig({
             'port': 0,
-            })
+            'interface': 'localhost',
+            'redis_config': redis._config,
+        })
+
+        service = yield start_server(config)
         port = service._port
         host = port.getHost()
         self.assertEqual(host.host, '127.0.0.1')

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -67,109 +67,109 @@ class TestCommandLine(JunebugTestBase):
         '''The redis host command line argument can be specified by
         "--redis-host" or "-redish" and has a default value of "localhost"'''
         config = parse_arguments([])
-        self.assertEqual(config.redis_config['host'], 'localhost')
+        self.assertEqual(config.redis['host'], 'localhost')
 
         config = parse_arguments(['--redis-host', 'foo.bar'])
-        self.assertEqual(config.redis_config['host'], 'foo.bar')
+        self.assertEqual(config.redis['host'], 'foo.bar')
 
         config = parse_arguments(['-redish', 'foo.bar'])
-        self.assertEqual(config.redis_config['host'], 'foo.bar')
+        self.assertEqual(config.redis['host'], 'foo.bar')
 
     def test_parse_arguments_redis_config_port(self):
         '''The redis port command line argument can be specified by
         "--redis-port" or "-redisp" and has a default value of 6379'''
         config = parse_arguments([])
-        self.assertEqual(config.redis_config['port'], 6379)
+        self.assertEqual(config.redis['port'], 6379)
 
         config = parse_arguments(['--redis-port', '80'])
-        self.assertEqual(config.redis_config['port'], 80)
+        self.assertEqual(config.redis['port'], 80)
 
         config = parse_arguments(['-redisp', '80'])
-        self.assertEqual(config.redis_config['port'], 80)
+        self.assertEqual(config.redis['port'], 80)
 
     def test_parse_arguments_redis_database(self):
         '''The redis database command line argument can be specified by
         "--redis-db" or "-redisdb" and has a default value of 0'''
         config = parse_arguments([])
-        self.assertEqual(config.redis_config['db'], 0)
+        self.assertEqual(config.redis['db'], 0)
 
         config = parse_arguments(['--redis-db', '80'])
-        self.assertEqual(config.redis_config['db'], 80)
+        self.assertEqual(config.redis['db'], 80)
 
         config = parse_arguments(['-redisdb', '80'])
-        self.assertEqual(config.redis_config['db'], 80)
+        self.assertEqual(config.redis['db'], 80)
 
     def test_parse_arguments_redis_password(self):
         '''The redis password command line argument can be specified by
         "--redis-password" or "-redispass" and has a default value of None'''
         config = parse_arguments([])
-        self.assertEqual(config.redis_config['password'], None)
+        self.assertEqual(config.redis['password'], None)
 
         config = parse_arguments(['--redis-password', 'foo.bar'])
-        self.assertEqual(config.redis_config['password'], 'foo.bar')
+        self.assertEqual(config.redis['password'], 'foo.bar')
 
         config = parse_arguments(['-redispass', 'foo.bar'])
-        self.assertEqual(config.redis_config['password'], 'foo.bar')
+        self.assertEqual(config.redis['password'], 'foo.bar')
 
     def test_parse_arguments_amqp_host(self):
         '''The amqp host command line argument can be specified by
         "--amqp-host" or "-amqph" and has a default value of "127.0.0.1"'''
         config = parse_arguments([])
-        self.assertEqual(config.amqp_config['hostname'], '127.0.0.1')
+        self.assertEqual(config.amqp['hostname'], '127.0.0.1')
 
         config = parse_arguments(['--amqp-host', 'foo.bar'])
-        self.assertEqual(config.amqp_config['hostname'], 'foo.bar')
+        self.assertEqual(config.amqp['hostname'], 'foo.bar')
 
         config = parse_arguments(['-amqph', 'foo.bar'])
-        self.assertEqual(config.amqp_config['hostname'], 'foo.bar')
+        self.assertEqual(config.amqp['hostname'], 'foo.bar')
 
     def test_parse_arguments_amqp_port(self):
         '''The amqp port command line argument can be specified by
         "--amqp-port" or "-amqpp" and has a default value of 5672'''
         config = parse_arguments([])
-        self.assertEqual(config.amqp_config['port'], 5672)
+        self.assertEqual(config.amqp['port'], 5672)
 
         config = parse_arguments(['--amqp-port', '80'])
-        self.assertEqual(config.amqp_config['port'], 80)
+        self.assertEqual(config.amqp['port'], 80)
 
         config = parse_arguments(['-amqpp', '80'])
-        self.assertEqual(config.amqp_config['port'], 80)
+        self.assertEqual(config.amqp['port'], 80)
 
     def test_parse_arguments_amqp_username(self):
         '''The amqp username command line argument can be specified by
         "--amqp-user" or "-amqpu" and has a default value of "guest"'''
         config = parse_arguments([])
-        self.assertEqual(config.amqp_config['username'], 'guest')
+        self.assertEqual(config.amqp['username'], 'guest')
 
         config = parse_arguments(['--amqp-user', 'test'])
-        self.assertEqual(config.amqp_config['username'], 'test')
+        self.assertEqual(config.amqp['username'], 'test')
 
         config = parse_arguments(['-amqpu', 'test'])
-        self.assertEqual(config.amqp_config['username'], 'test')
+        self.assertEqual(config.amqp['username'], 'test')
 
     def test_parse_arguments_amqp_password(self):
         '''The amqp password command line argument can be specified by
         "--amqp-password" or "-amqppass" and has a default value of "guest"'''
         config = parse_arguments([])
-        self.assertEqual(config.amqp_config['password'], 'guest')
+        self.assertEqual(config.amqp['password'], 'guest')
 
         config = parse_arguments(['--amqp-password', 'foo.bar'])
-        self.assertEqual(config.amqp_config['password'], 'foo.bar')
+        self.assertEqual(config.amqp['password'], 'foo.bar')
 
         config = parse_arguments(['-amqppass', 'foo.bar'])
-        self.assertEqual(config.amqp_config['password'], 'foo.bar')
+        self.assertEqual(config.amqp['password'], 'foo.bar')
 
     def test_parse_arguments_amqp_vhost(self):
         '''The amqp vhost command line argument can be specified by
         "--amqp-vhost" or "-amqpv" and has a default value of "/"'''
         config = parse_arguments([])
-        self.assertEqual(config.amqp_config['vhost'], '/')
+        self.assertEqual(config.amqp['vhost'], '/')
 
         config = parse_arguments(['--amqp-vhost', 'foo.bar'])
-        self.assertEqual(config.amqp_config['vhost'], 'foo.bar')
+        self.assertEqual(config.amqp['vhost'], 'foo.bar')
 
         config = parse_arguments(['-amqpv', 'foo.bar'])
-        self.assertEqual(config.amqp_config['vhost'], 'foo.bar')
+        self.assertEqual(config.amqp['vhost'], 'foo.bar')
 
     def test_config_file(self):
         '''The config file command line argument can be specified by
@@ -179,8 +179,8 @@ class TestCommandLine(JunebugTestBase):
                 'interface': 'lolcathost',
                 'port': 1337,
                 'logfile': 'stuff.log',
-                'redis_config': {'host': 'rawrcathost'},
-                'amqp_config': {'hostname': 'xorcathost'},
+                'redis': {'host': 'rawrcathost'},
+                'amqp': {'hostname': 'xorcathost'},
             }
         })
 
@@ -188,15 +188,15 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.interface, 'lolcathost')
         self.assertEqual(config.port, 1337)
         self.assertEqual(config.logfile, 'stuff.log')
-        self.assertEqual(config.redis_config['host'], 'rawrcathost')
-        self.assertEqual(config.amqp_config['hostname'], 'xorcathost')
+        self.assertEqual(config.redis['host'], 'rawrcathost')
+        self.assertEqual(config.amqp['hostname'], 'xorcathost')
 
         config = parse_arguments(['-c', '/foo/bar.yaml'])
         self.assertEqual(config.interface, 'lolcathost')
         self.assertEqual(config.port, 1337)
         self.assertEqual(config.logfile, 'stuff.log')
-        self.assertEqual(config.redis_config['host'], 'rawrcathost')
-        self.assertEqual(config.amqp_config['hostname'], 'xorcathost')
+        self.assertEqual(config.redis['host'], 'rawrcathost')
+        self.assertEqual(config.amqp['hostname'], 'xorcathost')
 
     def test_config_file_overriding(self):
         '''Config file options are overriden by their corresponding command
@@ -206,8 +206,8 @@ class TestCommandLine(JunebugTestBase):
                 'interface': 'lolcathost',
                 'port': 1337,
                 'logfile': 'stuff.log',
-                'redis_config': {'host': 'rawrcathost'},
-                'amqp_config': {'hostname': 'xorcathost'},
+                'redis': {'host': 'rawrcathost'},
+                'amqp': {'hostname': 'xorcathost'},
             }
         })
 
@@ -223,8 +223,8 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.interface, 'zuulcathost')
         self.assertEqual(config.port, 1620)
         self.assertEqual(config.logfile, 'logs.log')
-        self.assertEqual(config.redis_config['host'], 'bluish')
-        self.assertEqual(config.amqp_config['hostname'], 'hpqma')
+        self.assertEqual(config.redis['host'], 'bluish')
+        self.assertEqual(config.amqp['hostname'], 'hpqma')
 
     def test_logging_setup(self):
         '''If filename is None, just a stdout logger is created, if filename
@@ -257,7 +257,7 @@ class TestCommandLine(JunebugTestBase):
         config = JunebugConfig({
             'port': 0,
             'interface': 'localhost',
-            'redis_config': redis._config,
+            'redis': redis._config,
         })
 
         service = yield start_server(config)

--- a/junebug/tests/test_service.py
+++ b/junebug/tests/test_service.py
@@ -3,6 +3,7 @@ from twisted.trial.unittest import TestCase
 
 from junebug import JunebugApi
 from junebug.service import JunebugService
+from junebug.config import JunebugConfig
 
 
 class TestJunebugService(TestCase):
@@ -22,7 +23,10 @@ class TestJunebugService(TestCase):
 
     @inlineCallbacks
     def test_start_service(self):
-        service = JunebugService('localhost', 0, {}, {})
+        service = JunebugService(JunebugConfig({
+            'host': '127.0.0.1',
+            'port': 0,
+        }))
 
         yield service.startService()
         server = service._port

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'jsonschema',
         'treq',
         'vumi',
+        'confmodel',
     ],
     entry_points='''
     [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'treq',
         'vumi',
         'confmodel',
+        'PyYAML',
     ],
     entry_points='''
     [console_scripts]


### PR DESCRIPTION
Currently, all config options are added from the command line. The goal of this is to be able to specify a configuration file that can also set all of these options, instead of specifying them in the command line.