### PR TITLE
add message sending application worker

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -154,7 +154,7 @@ class Channel(object):
         return status
 
     @classmethod
-    def _api_from_message(cls, msg):
+    def api_from_message(cls, msg):
         ret = {}
         ret['to'] = msg['to_addr']
         ret['from'] = msg['from_addr']
@@ -171,7 +171,7 @@ class Channel(object):
         return ret
 
     @classmethod
-    def _message_from_api(cls, id, msg):
+    def message_from_api(cls, id, msg):
         ret = {}
         ret['to_addr'] = msg.get('to')
         ret['from_addr'] = msg['from']
@@ -191,7 +191,7 @@ class Channel(object):
         '''Sends a message. Takes a junebug.amqp.MessageSender instance to
         send a message.'''
         message = TransportUserMessage.send(
-            **cls._message_from_api(id, msg))
+            **cls.message_from_api(id, msg))
         queue = '%s.outbound' % id
         msg = yield message_sender.send_message(message, routing_key=queue)
-        returnValue(cls._api_from_message(msg))
+        returnValue(cls.api_from_message(msg))

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -175,7 +175,7 @@ class TestChannel(JunebugTestBase):
             content=None, from_addr='+1234', to_addr='+5432',
             transport_name='testtransport', continue_session=True,
             helper_metadata={'voice': {}})
-        dct = channel._api_from_message(message)
+        dct = channel.api_from_message(message)
         [dct.pop(f) for f in ['timestamp', 'message_id']]
         self.assertEqual(dct, {
             'channel_data': {
@@ -193,7 +193,7 @@ class TestChannel(JunebugTestBase):
     def test_message_from_api(self):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
-        msg = Channel._message_from_api(
+        msg = Channel.message_from_api(
             'channel-id', {
                 'from': '+1234',
                 'content': None,

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -1,0 +1,106 @@
+import treq
+import json
+from klein import Klein
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.web.client import HTTPConnectionPool
+from twisted.web.server import Site
+from vumi.application.tests.helpers import ApplicationHelper
+from vumi.message import TransportUserMessage
+
+from junebug.workers import MessageForwardingWorker
+from junebug.tests.helpers import JunebugTestBase
+
+
+class RequestLoggingApi(object):
+    app = Klein()
+
+    def __init__(self):
+        self.requests = []
+
+    @app.route('/')
+    def log_request(self, request):
+        self.requests.append({
+            'request': request,
+            'body': request.content.read(),
+            })
+        return ''
+
+    @app.route('/bad/')
+    def bad_request(self, request):
+        self.requests.append({
+            'request': request,
+            'body': request.content.read(),
+            })
+        request.setResponseCode(500)
+        return 'test-error-response'
+
+
+class TestMessageForwardingWorker(JunebugTestBase):
+    @inlineCallbacks
+    def setUp(self):
+        self.logging_api = RequestLoggingApi()
+        port = reactor.listenTCP(
+            0, Site(self.logging_api.app.resource()),
+            interface='127.0.0.1')
+        self.addCleanup(port.stopListening)
+        addr = port.getHost()
+        self.url = "http://%s:%s" % (addr.host, addr.port)
+
+        app_config = {
+            'transport_name': 'testtransport',
+            'mo_message_url': self.url,
+        }
+        self.worker = yield self.get_worker(app_config)
+
+        connection_pool = HTTPConnectionPool(reactor, persistent=False)
+        treq._utils.set_global_pool(connection_pool)
+
+    @inlineCallbacks
+    def get_worker(self, config):
+        '''Get a new MessageForwardingWorker with the provided config'''
+        app_helper = ApplicationHelper(MessageForwardingWorker)
+        yield app_helper.setup()
+        self.addCleanup(app_helper.cleanup)
+        worker = yield app_helper.get_application(config)
+        returnValue(worker)
+
+    @inlineCallbacks
+    def test_send_message(self):
+        '''A sent message should be forwarded to the configured URL'''
+        msg = TransportUserMessage.send(to_addr='+1234', content='testcontent')
+        yield self.worker.consume_user_message(msg)
+        [request] = self.logging_api.requests
+        req = request['request']
+        body = json.loads(request['body'])
+
+        self.assertEqual(
+            req.requestHeaders.getRawHeaders('content-type'),
+            ['application/json'])
+        self.assertEqual(req.method, 'POST')
+        self.assertEqual(body['content'], 'testcontent')
+        self.assertEqual(body['to'], '+1234')
+
+    @inlineCallbacks
+    def test_send_message_bad_response(self):
+        '''If there is an error sending a message to the configured URL, the
+        error and message should be logged'''
+        self.patch_logger()
+        self.worker = yield self.get_worker({
+            'transport_name': 'testtransport',
+            'mo_message_url': self.url + '/bad/'})
+        msg = TransportUserMessage.send(to_addr='+1234', content='testcontent')
+        yield self.worker.consume_user_message(msg)
+
+        self.assertTrue(any(
+            '"content": "testcontent"' in l.getMessage()
+            for l in self.logging_handler.buffer))
+        self.assertTrue(any(
+            '"to": "+1234"' in l.getMessage()
+            for l in self.logging_handler.buffer))
+        self.assertTrue(any(
+            '500' in l.getMessage()
+            for l in self.logging_handler.buffer))
+        self.assertTrue(any(
+            'test-error-response' in l.getMessage()
+            for l in self.logging_handler.buffer))

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -1,0 +1,40 @@
+import json
+import logging
+from twisted.internet.defer import inlineCallbacks
+import treq
+from vumi.application.base import ApplicationConfig, ApplicationWorker
+from vumi.config import ConfigText
+from vumi.message import JSONMessageEncoder
+
+from junebug.channel import Channel
+
+
+class MessageForwardingConfig(ApplicationConfig):
+    '''Config for MessageForwardingWorker application worker'''
+
+    mo_message_url = ConfigText(
+        'The URL to send HTTP POST requests to for MO messages',
+        required=True, static=True)
+
+
+class MessageForwardingWorker(ApplicationWorker):
+    '''This application worker consumes vumi messages placed on a configured
+    amqp queue, and sends them as HTTP requests with a JSON body to a
+    configured URL'''
+    CONFIG_CLASS = MessageForwardingConfig
+
+    @inlineCallbacks
+    def consume_user_message(self, message):
+        '''Sends the vumi message as an HTTP request to the configured URL'''
+        config = yield self.get_config(message)
+        url = config.mo_message_url
+        headers = {
+            'Content-Type': 'application/json',
+        }
+        msg = json.dumps(
+            Channel._api_from_message(message), cls=JSONMessageEncoder)
+        resp = yield treq.post(url, data=msg, headers=headers)
+        if resp.code < 200 or resp.code >= 300:
+            logging.exception(
+                'Error sending message, received HTTP code %r with body %r. '
+                'Message: %r' % (resp.code, (yield resp.content()), msg))

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -32,7 +32,7 @@ class MessageForwardingWorker(ApplicationWorker):
             'Content-Type': 'application/json',
         }
         msg = json.dumps(
-            Channel._api_from_message(message), cls=JSONMessageEncoder)
+            Channel.api_from_message(message), cls=JSONMessageEncoder)
         resp = yield treq.post(url, data=msg, headers=headers)
         if resp.code < 200 or resp.code >= 300:
             logging.exception(


### PR DESCRIPTION
We need an application worker that will take MO messages and send them to the provided URL. The plan is that a separate PR will handle the starting/stopping of the worker (when channels are started/stopped). 