### PR TITLE
Create, start and stop application workers with their transport workers

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -39,6 +39,8 @@ allowed_message_fields = [
 
 
 class Channel(object):
+    APPLICATION_ID = 'application:%s'
+
     def __init__(
             self, redis_manager, amqp_config, properties, id=None):
         '''Creates a new channel. ``redis_manager`` is the redis manager, from
@@ -55,6 +57,10 @@ class Channel(object):
 
         self.transport_worker = None
         self.application_worker = None
+
+    @property
+    def application_id(self):
+        return self.APPLICATION_ID % (self.id,)
 
     def start(self, service, transport_worker=None):
         '''Starts the relevant workers for the channel. ``service`` is the
@@ -173,10 +179,6 @@ class Channel(object):
         return ret
 
     @property
-    def _application_id(self):
-        return 'application:%s' % (self.id,)
-
-    @property
     def _transport_config(self):
         config = self._properties['config']
         config = self._convert_unicode(config)
@@ -218,7 +220,7 @@ class Channel(object):
 
     def _start_application(self, service):
         worker = self._create_application()
-        worker.setName(self._application_id)
+        worker.setName(self.application_id)
         worker.setServiceParent(service)
         self.application_worker = worker
 
@@ -251,7 +253,7 @@ class Channel(object):
 
     def _restore(self, service):
         self.transport_worker = service.getServiceNamed(self.id)
-        self.application_worker = service.getServiceNamed(self._application_id)
+        self.application_worker = service.getServiceNamed(self.application_id)
 
     def _convert_unicode(self, data):
         # Twisted doesn't like it when we give unicode in for config things

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -40,6 +40,7 @@ allowed_message_fields = [
 
 class Channel(object):
     APPLICATION_ID = 'application:%s'
+    APPLICATION_CLS_NAME = 'junebug.workers.MessageForwardingWorker'
 
     def __init__(
             self, redis_manager, amqp_config, properties, id=None):
@@ -204,10 +205,6 @@ class Channel(object):
 
         return cls_name
 
-    @property
-    def _application_cls_name(self):
-        return 'junebug.workers.MessageForwardingWorker'
-
     def _start_transport(self, service, transport_worker):
         # transport_worker parameter is for testing, if it is None,
         # create the transport worker
@@ -231,7 +228,7 @@ class Channel(object):
 
     def _create_application(self):
         return self._create_worker(
-            self._application_cls_name,
+            self.APPLICATION_CLS_NAME,
             self._application_config)
 
     def _create_worker(self, cls_name, config):

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -62,6 +62,11 @@ class JunebugTestBase(TestCase):
         self.logging_handler.close()
         logging.getLogger().removeHandler(self.logging_handler)
 
+    def create_channel_config(self, **kw):
+        config = deepcopy(self.default_channel_config)
+        config.update(kw)
+        return config
+
     @inlineCallbacks
     def create_channel(
             self, service, redis, transport_class,

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -221,17 +221,18 @@ class TestJunebugApi(JunebugTestBase):
     @inlineCallbacks
     def test_modify_channel_config_change(self):
         redis = yield self.get_redis()
-        channel = Channel(
-            redis, {}, self.default_channel_config, 'test-channel')
+        config = self.create_channel_config()
+
+        channel = Channel(redis, {}, config, 'test-channel')
         yield channel.save()
         yield channel.start(self.service)
-        resp = yield self.post(
-            '/channels/test-channel', {'config': {'name': 'bar'}})
-        expected = deepcopy(self.default_channel_config)
+
+        config['config']['name'] = 'bar'
+        resp = yield self.post('/channels/test-channel', config)
+        expected = deepcopy(config)
         expected.update({
             'status': {},
             'id': 'test-channel',
-            'config': {'name': 'bar'},
             })
         yield self.assert_response(
             resp, http.OK, 'channel updated', expected)

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -118,6 +118,25 @@ class TestJunebugApi(JunebugTestBase):
         self.assertTrue(transport.running)
 
     @inlineCallbacks
+    def test_create_channel_application(self):
+        resp = yield self.post('/channels/', {
+            'type': 'telnet',
+            'config': self.default_channel_config,
+            'mo_url': 'http://foo.bar',
+        })
+
+        channel_id = (yield resp.json())['result']['id']
+        id = Channel.APPLICATION_ID % (channel_id,)
+        worker = self.service.namedServices[id]
+
+        self.assertEqual(worker.parent, self.service)
+
+        self.assertEqual(worker.config, {
+            'transport_name': channel_id,
+            'mo_message_url': 'http://foo.bar'
+        })
+
+    @inlineCallbacks
     def test_create_channel_invalid_parameters(self):
         resp = yield self.post('/channels/', {
             'type': 'smpp',

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -61,8 +61,11 @@ class TestChannel(JunebugTestBase):
 
         self.assertTrue(isinstance(worker, MessageForwardingWorker))
         self.assertEqual(self.service.namedServices[id], worker)
-        self.assertEqual(worker.config['transport_name'], channel.id)
-        self.assertEqual(worker.config['mo_message_url'], 'http://foo.org')
+
+        self.assertEqual(worker.config, {
+            'transport_name': channel.id,
+            'mo_message_url': 'http://foo.org'
+        })
 
     @inlineCallbacks
     def test_create_channel_invalid_type(self):
@@ -134,6 +137,9 @@ class TestChannel(JunebugTestBase):
 
         yield channel.stop()
         self.assertEqual(self.service.namedServices.get(channel.id), None)
+
+        application_id = channel._application_id
+        self.assertEqual(self.service.namedServices.get(application_id), None)
 
     @inlineCallbacks
     def test_create_channel_from_id(self):

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -41,7 +41,7 @@ class TestChannel(JunebugTestBase):
         self.assertEqual(properties, None)
 
     @inlineCallbacks
-    def test_start_channel(self):
+    def test_start_channel_transport(self):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
 

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -56,9 +56,8 @@ class TestChannel(JunebugTestBase):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, config)
 
-        id = 'application:%s' % (channel.id,)
         worker = channel.application_worker
-
+        id = channel.application_id
         self.assertTrue(isinstance(worker, MessageForwardingWorker))
         self.assertEqual(self.service.namedServices[id], worker)
 
@@ -114,7 +113,7 @@ class TestChannel(JunebugTestBase):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
         worker1 = channel.application_worker
-        id = 'application:%s' % (channel.id,)
+        id = channel.application_id
 
         self.assertEqual(self.service.namedServices[id], worker1)
         yield channel.update({'foo': 'bar'})
@@ -138,7 +137,7 @@ class TestChannel(JunebugTestBase):
         yield channel.stop()
         self.assertEqual(self.service.namedServices.get(channel.id), None)
 
-        application_id = channel._application_id
+        application_id = channel.application_id
         self.assertEqual(self.service.namedServices.get(application_id), None)
 
     @inlineCallbacks

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -119,8 +119,7 @@ class TestChannel(JunebugTestBase):
         yield channel.update({'foo': 'bar'})
         self.assertEqual(self.service.namedServices[id], worker1)
 
-        config = self.create_channel_config()
-        config['config']['foo'] = ['bar']
+        config = self.create_channel_config(mo_url='http://baz.org')
         yield channel.update(config)
 
         worker2 = channel.application_worker

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -106,7 +106,7 @@ class TestChannel(JunebugTestBase):
 
         worker2 = channel.transport_worker
         self.assertEqual(self.service.namedServices[channel.id], worker2)
-        self.assertNotEqual(worker1, worker2)
+        self.assertTrue(worker1 not in self.service.services)
 
     @inlineCallbacks
     def test_update_channel_restart_application_on_config_change(self):
@@ -125,7 +125,7 @@ class TestChannel(JunebugTestBase):
 
         worker2 = channel.application_worker
         self.assertEqual(self.service.namedServices[id], worker2)
-        self.assertNotEqual(worker1, worker2)
+        self.assertTrue(worker1 not in self.service.services)
 
     @inlineCallbacks
     def test_stop_channel(self):

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -210,7 +210,7 @@ class TestChannel(JunebugTestBase):
     def test_send_message(self):
         '''The send_message function should place the message on the correct
         queue'''
-        channel = yield self.create_channel(
+        yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
         msg = yield Channel.send_message(
             'channel-id', self.api.message_sender, {
@@ -251,7 +251,7 @@ class TestChannel(JunebugTestBase):
 
     @inlineCallbacks
     def test_message_from_api(self):
-        channel = yield self.create_channel(
+        yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
         msg = Channel._message_from_api(
             'channel-id', {


### PR DESCRIPTION
#20 adds an application worker for `POST`ing mo messages to a url. We plan to have one application worker instance per transport instance, and create, start and stop each application worker with its corresponding transport worker.