### PR TITLE
Fix mo_url in message forwarding worker

### DIFF
--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -49,7 +49,7 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         app_config = {
             'transport_name': 'testtransport',
-            'mo_message_url': self.url,
+            'mo_message_url': unicode(self.url),
         }
         self.worker = yield self.get_worker(app_config)
 

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -49,7 +49,7 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         app_config = {
             'transport_name': 'testtransport',
-            'mo_message_url': unicode(self.url),
+            'mo_message_url': self.url.decode('utf-8'),
         }
         self.worker = yield self.get_worker(app_config)
 

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -27,7 +27,7 @@ class MessageForwardingWorker(ApplicationWorker):
     def consume_user_message(self, message):
         '''Sends the vumi message as an HTTP request to the configured URL'''
         config = yield self.get_config(message)
-        url = config.mo_message_url
+        url = str(config.mo_message_url)
         headers = {
             'Content-Type': 'application/json',
         }

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -27,7 +27,7 @@ class MessageForwardingWorker(ApplicationWorker):
     def consume_user_message(self, message):
         '''Sends the vumi message as an HTTP request to the configured URL'''
         config = yield self.get_config(message)
-        url = str(config.mo_message_url)
+        url = config.mo_message_url.encode('utf-8')
         headers = {
             'Content-Type': 'application/json',
         }


### PR DESCRIPTION
Currently, getting the `mo_url` from the config results in unicode. We must convert this to bytes before trying to make an http request.