### PR TITLE
Don't patch transport worker creation in api tests

### DIFF
--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -9,7 +9,7 @@ from txamqp.client import TwistedDelegate
 from vumi.utils import vumi_resource_path
 from vumi.service import get_spec
 from vumi.tests.fake_amqp import FakeAMQPBroker, FakeAMQPChannel
-from vumi.tests.helpers import PersistenceHelper, WorkerHelper
+from vumi.tests.helpers import PersistenceHelper
 
 from junebug import JunebugApi
 from junebug.amqp import JunebugAMQClient, MessageSender
@@ -77,11 +77,7 @@ class JunebugTestBase(TestCase):
         config = deepcopy(config)
         channel = Channel(redis, {}, config, id=id)
         config['config']['transport_name'] = channel.id
-        wh = WorkerHelper()
-        transport_worker = yield wh.get_worker(
-            transport_class, config['config'])
-        self.addCleanup(wh.cleanup)
-        yield channel.start(self.service, transport_worker)
+        yield channel.start(self.service)
         yield channel.save()
         self.addCleanup(channel.stop)
         returnValue(channel)

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -98,9 +98,10 @@ class TestJunebugApi(JunebugTestBase):
         transport = self.service.namedServices[id]
 
         self.assertEqual(transport.parent, self.service)
-        self.assertEqual(transport.config['transport_name'], id)
-        self.assertEqual(transport.config['twisted_endpoint'], 'tcp:0')
-        self.assertEqual(transport.config['worker_name'], 'unnamed')
+
+        self.assertEqual(transport.config, conjoin(config['config'], {
+            'transport_name': id,
+        }))
 
     @inlineCallbacks
     def test_create_channel_application(self):

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -1,13 +1,12 @@
-from copy import deepcopy
 import json
 from twisted.internet.defer import inlineCallbacks
 from vumi.message import TransportUserMessage
 from vumi.transports.telnet import TelnetServerTransport
-from vumi.application.base import ApplicationWorker
 
 from junebug.workers import MessageForwardingWorker
 from junebug.channel import Channel, ChannelNotFound, InvalidChannelType
 from junebug.tests.helpers import JunebugTestBase
+from junebug.tests.utils import conjoin
 
 
 class TestChannel(JunebugTestBase):
@@ -20,21 +19,26 @@ class TestChannel(JunebugTestBase):
 
     @inlineCallbacks
     def test_save_channel(self):
+        config = self.create_channel_config()
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
         properties = yield self.redis.get('%s:properties' % channel.id)
-        expected = deepcopy(self.default_channel_config)
-        expected['config']['transport_name'] = channel.id
-        self.assertEqual(json.loads(properties), expected)
+
+        self.assertEqual(json.loads(properties), conjoin(config, {
+            'config': conjoin(config['config'], {'transport_name': channel.id})
+        }))
 
     @inlineCallbacks
     def test_delete_channel(self):
+        config = self.create_channel_config()
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
+
         properties = yield self.redis.get('%s:properties' % channel.id)
-        expected = deepcopy(self.default_channel_config)
-        expected['config']['transport_name'] = channel.id
-        self.assertEqual(json.loads(properties), expected)
+
+        self.assertEqual(json.loads(properties), conjoin(config, {
+            'config': conjoin(config['config'], {'transport_name': channel.id})
+        }))
 
         yield channel.delete()
         properties = yield self.redis.get('%s:properties' % channel.id)
@@ -77,18 +81,21 @@ class TestChannel(JunebugTestBase):
 
     @inlineCallbacks
     def test_update_channel_config(self):
+        config = self.create_channel_config()
+
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
 
         update = yield channel.update({'foo': 'bar'})
-        expected = deepcopy(self.default_channel_config)
-        expected.update({
+
+        self.assertEqual(update, conjoin(config, {
             'foo': 'bar',
             'status': {},
             'id': channel.id,
+            'config': conjoin(config['config'], {
+                'transport_name': channel.id
             })
-        expected['config']['transport_name'] = channel.id
-        self.assertEqual(update, expected)
+        }))
 
     @inlineCallbacks
     def test_update_channel_restart_transport_on_config_change(self):
@@ -166,15 +173,17 @@ class TestChannel(JunebugTestBase):
 
     @inlineCallbacks
     def test_channel_status(self):
+        config = self.create_channel_config()
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
-        expected = deepcopy(self.default_channel_config)
-        expected.update({
-            'id': 'channel-id',
+
+        self.assertEqual((yield channel.status()), conjoin(config, {
             'status': {},
+            'id': 'channel-id',
+            'config': conjoin(config['config'], {
+                'transport_name': channel.id
             })
-        expected['config']['transport_name'] = channel.id
-        self.assertEqual((yield channel.status()), expected)
+        }))
 
     @inlineCallbacks
     def test_get_all_channels(self):

--- a/junebug/tests/utils.py
+++ b/junebug/tests/utils.py
@@ -26,3 +26,10 @@ class ToyServer(object):
         yield server.setup(app)
         test.addCleanup(server.teardown)
         returnValue(server)
+
+
+def conjoin(a, b):
+    result = {}
+    result.update(a)
+    result.update(b)
+    return result


### PR DESCRIPTION
It would be cool if we could let `Channel` do its usual transport creation.