### PR TITLE
Remove channel from channel list when deleting

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -108,6 +108,7 @@ class Channel(object):
         '''Removes the channel data from redis'''
         channel_redis = yield self.redis.sub_manager(self.id)
         yield channel_redis.delete('properties')
+        yield self.redis.srem('channels', self.id)
 
     def status(self):
         '''Returns a dict with the configuration and status of the channel'''

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -22,19 +22,14 @@ class TestChannel(JunebugTestBase):
         config = self.create_channel_config()
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
-        properties = yield self.redis.get('%s:properties' % channel.id)
-<<<<<<< HEAD
-        expected = deepcopy(self.default_channel_config)
-        expected['config']['transport_name'] = channel.id
-        self.assertEqual(json.loads(properties), expected)
-        channel_list = yield self.redis.get('channels')
-        self.assertEqual(channel_list, set([channel.id]))
-=======
 
+        properties = yield self.redis.get('%s:properties' % channel.id)
         self.assertEqual(json.loads(properties), conjoin(config, {
             'config': conjoin(config['config'], {'transport_name': channel.id})
         }))
->>>>>>> develop
+
+        channel_list = yield self.redis.get('channels')
+        self.assertEqual(channel_list, set([channel.id]))
 
     @inlineCallbacks
     def test_delete_channel(self):
@@ -43,18 +38,12 @@ class TestChannel(JunebugTestBase):
             self.service, self.redis, TelnetServerTransport)
 
         properties = yield self.redis.get('%s:properties' % channel.id)
-<<<<<<< HEAD
-        expected = deepcopy(self.default_channel_config)
-        expected['config']['transport_name'] = channel.id
-        self.assertEqual(json.loads(properties), expected)
-        channel_list = yield self.redis.get('channels')
-        self.assertEqual(channel_list, set([channel.id]))
-=======
-
         self.assertEqual(json.loads(properties), conjoin(config, {
             'config': conjoin(config['config'], {'transport_name': channel.id})
         }))
->>>>>>> develop
+
+        channel_list = yield self.redis.get('channels')
+        self.assertEqual(channel_list, set([channel.id]))
 
         yield channel.delete()
         properties = yield self.redis.get('%s:properties' % channel.id)

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -26,6 +26,8 @@ class TestChannel(JunebugTestBase):
         expected = deepcopy(self.default_channel_config)
         expected['config']['transport_name'] = channel.id
         self.assertEqual(json.loads(properties), expected)
+        channel_list = yield self.redis.get('channels')
+        self.assertEqual(channel_list, set([channel.id]))
 
     @inlineCallbacks
     def test_delete_channel(self):
@@ -35,10 +37,15 @@ class TestChannel(JunebugTestBase):
         expected = deepcopy(self.default_channel_config)
         expected['config']['transport_name'] = channel.id
         self.assertEqual(json.loads(properties), expected)
+        channel_list = yield self.redis.get('channels')
+        self.assertEqual(channel_list, set([channel.id]))
 
         yield channel.delete()
         properties = yield self.redis.get('%s:properties' % channel.id)
         self.assertEqual(properties, None)
+
+        channel_list = yield self.redis.get('channels')
+        self.assertEqual(channel_list, set())
 
     @inlineCallbacks
     def test_start_channel_transport(self):


### PR DESCRIPTION
Currently, we delete the channel data from redis, but we don't remove the channel id from the channel list.