### PR TITLE
Create inbound message store

### DIFF
--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -31,10 +31,9 @@ class BaseStore(object):
     def load_property(self, prop):
         self.properties[prop] = yield self.redis.hget(self.id, prop)
 
-    @inlineCallbacks
     def set_property(self, prop, value):
-        yield self.redis.hset(self.id, prop, value)
         self.properties[prop] = value
+        return succeed(None)
 
     def get_property(self, prop):
         return succeed(self.properties.get(prop))

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -1,0 +1,38 @@
+from twisted.internet.defer import inlineCallbacks, succeed, returnValue
+
+
+class BaseStore(object):
+    '''Base class for store objects. Stores data in redis in a hash.
+    redis: redis manager
+    ttl: expiry for the key
+    id: key to store the hash under
+    properties: the keys and values of the hash
+    '''
+
+    def __init__(self, id, properties, redis, ttl):
+        self.id, self.properties, self.redis, self.ttl = (
+            id, properties, redis, ttl)
+
+    @inlineCallbacks
+    def save_all(self):
+        yield self.redis.hmset(self.id, self.properties)
+        yield self.redis.expire(self.id, self.ttl)
+
+    @inlineCallbacks
+    def load_all(self):
+        self.properties = (yield self.redis.hgetall(self.id)) or {}
+
+    @inlineCallbacks
+    def set_property(self, prop, value):
+        yield self.redis.hset(self.id, prop, value)
+        self.properties[prop] = value
+
+    def get_property(self, prop):
+        return succeed(self.properties.get(prop))
+
+    @classmethod
+    @inlineCallbacks
+    def from_id(cls, id, redis, ttl):
+        store = cls(id, {}, redis, ttl)
+        yield store.load_all()
+        returnValue(store)

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -15,7 +15,7 @@ class MessageNotFound(JunebugError):
 class BaseStore(object):
     '''Base class for store objects. Stores data in redis in a hash.
     redis: redis manager
-    ttl: expiry for the key
+    ttl: expiry for keys in the store
     '''
 
     def __init__(self, redis, ttl):

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -3,13 +3,19 @@ from vumi.message import TransportUserMessage
 
 
 class BaseStore(object):
-    '''Base class for store objects. Stores data in redis in a hash.
-    redis: redis manager
-    ttl: expiry for keys in the store
     '''
+    .. class:: junebug.stores.BaseStore(redis, ttl)
 
+       Base class for store classes. Stores data in redis as a hash.
+
+       :param redis: Redis manager
+       :type redis: :class:`vumi.persist.redis_manager.RedisManager`
+       :param ttl: Expiry time for keys in the store
+       :type ttl: integer
+    '''
     def __init__(self, redis, ttl):
-        self.redis, self.ttl = redis, ttl
+        self.redis = redis
+        self.ttl = ttl
 
     @inlineCallbacks
     def _redis_op(self, func, id, *args, **kwargs):

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -1,5 +1,15 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.web import http
 from vumi.message import TransportUserMessage
+
+from junebug.error import JunebugError
+
+
+class MessageNotFound(JunebugError):
+    '''Raised when a message cannot be found.'''
+    name = 'MessageNotFound'
+    description = 'message not found'
+    code = http.NOT_FOUND
 
 
 class BaseStore(object):
@@ -48,4 +58,7 @@ class InboundMessageStore(BaseStore):
     def load_vumi_message(self, message_id):
         '''Retrieves the stored vumi message, given its unique id'''
         msg_json = yield self.load_property(message_id, 'message')
+        if msg_json is None:
+            raise MessageNotFound(
+                'Cannot find message with id %s' % (message_id,))
         returnValue(TransportUserMessage.from_json(msg_json))

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -4,14 +4,12 @@ from vumi.message import TransportUserMessage
 
 class BaseStore(object):
     '''
-    .. class:: junebug.stores.BaseStore(redis, ttl)
+   Base class for store classes. Stores data in redis as a hash.
 
-       Base class for store classes. Stores data in redis as a hash.
-
-       :param redis: Redis manager
-       :type redis: :class:`vumi.persist.redis_manager.RedisManager`
-       :param ttl: Expiry time for keys in the store
-       :type ttl: integer
+   :param redis: Redis manager
+   :type redis: :class:`vumi.persist.redis_manager.RedisManager`
+   :param ttl: Expiry time for keys in the store
+   :type ttl: integer
     '''
     def __init__(self, redis, ttl):
         self.redis = redis

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -1,15 +1,5 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.web import http
 from vumi.message import TransportUserMessage
-
-from junebug.error import JunebugError
-
-
-class MessageNotFound(JunebugError):
-    '''Raised when a message cannot be found.'''
-    name = 'MessageNotFound'
-    description = 'message not found'
-    code = http.NOT_FOUND
 
 
 class BaseStore(object):
@@ -59,6 +49,5 @@ class InboundMessageStore(BaseStore):
         '''Retrieves the stored vumi message, given its unique id'''
         msg_json = yield self.load_property(message_id, 'message')
         if msg_json is None:
-            raise MessageNotFound(
-                'Cannot find message with id %s' % (message_id,))
+            returnValue(None)
         returnValue(TransportUserMessage.from_json(msg_json))

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -110,6 +110,7 @@ class TestInboundMessageStore(JunebugTestBase):
 
     @inlineCallbacks
     def test_load_vumi_message_not_exist(self):
+        '''An exception should be raised if the message cannot be found'''
         store = yield self.create_store()
         err = yield self.assertFailure(
             store.load_vumi_message('bad-id'), MessageNotFound)

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -1,7 +1,7 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
 from vumi.message import TransportUserMessage
 
-from junebug.stores import BaseStore, InboundMessageStore, MessageNotFound
+from junebug.stores import BaseStore, InboundMessageStore
 from junebug.tests.helpers import JunebugTestBase
 
 
@@ -110,8 +110,6 @@ class TestInboundMessageStore(JunebugTestBase):
 
     @inlineCallbacks
     def test_load_vumi_message_not_exist(self):
-        '''An exception should be raised if the message cannot be found'''
+        '''`None` should be returned if the message cannot be found'''
         store = yield self.create_store()
-        err = yield self.assertFailure(
-            store.load_vumi_message('bad-id'), MessageNotFound)
-        self.assertIn('bad-id', err.message)
+        self.assertEqual((yield store.load_vumi_message('bad-id')), None)

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -90,10 +90,10 @@ class TestBaseStore(JunebugTestBase):
 
     @inlineCallbacks
     def test_set_property(self):
-        '''Set the property in redis and on the store properties'''
+        '''Set the property on the store properties'''
         store = yield self.create_store()
         yield store.set_property('foo', 'bar')
-        self.assertEqual((yield self.redis.hget('testid', 'foo')), 'bar')
+        self.assertEqual(store.properties['foo'], 'bar')
 
     @inlineCallbacks
     def test_get_property(self):

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -1,7 +1,7 @@
 from twisted.internet.defer import inlineCallbacks, returnValue
 from vumi.message import TransportUserMessage
 
-from junebug.stores import BaseStore, InboundMessageStore
+from junebug.stores import BaseStore, InboundMessageStore, MessageNotFound
 from junebug.tests.helpers import JunebugTestBase
 
 
@@ -98,7 +98,7 @@ class TestInboundMessageStore(JunebugTestBase):
         self.assertEqual(vumi_msg, TransportUserMessage.from_json(msg))
 
     @inlineCallbacks
-    def test_get(self):
+    def test_load_vumi_message(self):
         '''Returns a vumi message from the stored json'''
         store = yield self.create_store()
         vumi_msg = TransportUserMessage.send(to_addr='+213', content='foo')
@@ -107,3 +107,10 @@ class TestInboundMessageStore(JunebugTestBase):
 
         message = yield store.load_vumi_message(vumi_msg.get('message_id'))
         self.assertEqual(message, vumi_msg)
+
+    @inlineCallbacks
+    def test_load_vumi_message_not_exist(self):
+        store = yield self.create_store()
+        err = yield self.assertFailure(
+            store.load_vumi_message('bad-id'), MessageNotFound)
+        self.assertIn('bad-id', err.message)

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -1,0 +1,88 @@
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+from junebug.stores import BaseStore
+from junebug.tests.helpers import JunebugTestBase
+
+
+class TestBaseStore(JunebugTestBase):
+    @inlineCallbacks
+    def create_store(self, id='testid', ttl=60, properties={}):
+        redis = yield self.get_redis()
+        store = BaseStore(id, properties, redis, ttl)
+        returnValue(store)
+
+    @inlineCallbacks
+    def test_save_all(self):
+        '''Stores all the keys and values in a hash in redis, and sets the
+        expiry time'''
+        store = yield self.create_store()
+        store.properties = {
+            'foo': 'bar',
+            'bar': 'foo',
+        }
+        yield store.save_all()
+
+        props = yield self.redis.hgetall('testid')
+        self.assertEqual(store.properties, props)
+
+        ttl = yield self.redis.ttl('testid')
+        self.assertEqual(ttl, 60)
+
+    @inlineCallbacks
+    def test_load_all_empty(self):
+        '''If no data exists in redis, properties should be an empty dict'''
+        store = yield self.create_store()
+        yield store.load_all()
+
+        self.assertEqual(store.properties, {})
+
+    @inlineCallbacks
+    def test_load_all(self):
+        '''If data exists in redis, properties should contain that data'''
+        store = yield self.create_store()
+
+        values = {
+            'foo': 'bar',
+            'bar': 'foo',
+        }
+
+        yield self.redis.hmset('testid', values)
+
+        yield store.load_all()
+        self.assertEqual(store.properties, values)
+
+    @inlineCallbacks
+    def test_set_property(self):
+        '''Set the property in redis and on the store properties'''
+        store = yield self.create_store()
+        yield store.set_property('foo', 'bar')
+        self.assertEqual((yield self.redis.hget('testid', 'foo')), 'bar')
+
+    @inlineCallbacks
+    def test_get_property(self):
+        '''Gets the value of the property from the store'''
+        store = yield self.create_store()
+        store.properties = {
+            'foo': 'bar',
+            'bar': 'foo',
+        }
+
+        self.assertEqual((yield store.get_property('foo')), 'bar')
+        self.assertEqual((yield store.get_property('bar')), 'foo')
+        self.assertEqual((yield store.get_property('baz')), None)
+
+    @inlineCallbacks
+    def test_from_id(self):
+        redis = yield self.get_redis()
+        yield redis.hmset('testid', {
+            'foo': 'bar',
+            'bar': 'foo',
+        })
+        store = yield BaseStore.from_id('testid', redis, 60)
+
+        self.assertEqual(store.id, 'testid')
+        self.assertEqual(store.ttl, 60)
+        self.assertEqual(store.properties, {
+            'foo': 'bar',
+            'bar': 'foo',
+            })

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -1,72 +1,64 @@
-from copy import deepcopy
 from twisted.internet.defer import inlineCallbacks, returnValue
 from vumi.message import TransportUserMessage
 
-from junebug.stores import BaseStore, InboundMessage
+from junebug.stores import BaseStore, InboundMessageStore
 from junebug.tests.helpers import JunebugTestBase
 
 
 class TestBaseStore(JunebugTestBase):
     @inlineCallbacks
-    def create_store(self, id='testid', ttl=60, properties={}):
+    def create_store(self, ttl=60):
         redis = yield self.get_redis()
-        store = BaseStore(id, deepcopy(properties), redis, ttl)
+        store = BaseStore(redis, ttl)
         returnValue(store)
 
     @inlineCallbacks
-    def test_save_all(self):
+    def test_store_all(self):
         '''Stores all the keys and values in a hash in redis, and sets the
         expiry time'''
         store = yield self.create_store()
-        store.properties = {
+        properties = {
             'foo': 'bar',
             'bar': 'foo',
         }
-        yield store.save_all()
+        yield store.store_all('testid', properties)
 
         props = yield self.redis.hgetall('testid')
-        self.assertEqual(store.properties, props)
+        self.assertEqual(properties, props)
 
         ttl = yield self.redis.ttl('testid')
         self.assertEqual(ttl, 60)
 
     @inlineCallbacks
-    def test_save_property(self):
-        '''Saves a single property into redis'''
+    def test_store_property(self):
+        '''Saves a single property into redis, and sets the expiry time'''
         store = yield self.create_store()
-        store.properties['foo'] = 'bar'
-        yield store.save_property('foo')
+        yield store.store_property('testid', 'foo', 'bar')
         self.assertEqual((yield self.redis.hget('testid', 'foo')), 'bar')
-
-    @inlineCallbacks
-    def test_save_property_empty(self):
-        '''Should save None intp redis if no value for the property exists'''
-        store = yield self.create_store()
-        yield store.save_property('foo')
-        self.assertEqual((yield self.redis.hget('testid', 'foo')), None)
+        self.assertEqual((yield self.redis.ttl('testid')), 60)
 
     @inlineCallbacks
     def test_load_all_empty(self):
         '''If no data exists in redis, properties should be an empty dict'''
         store = yield self.create_store()
-        yield store.load_all()
+        properties = yield store.load_all('testid')
 
-        self.assertEqual(store.properties, {})
+        self.assertEqual(properties, {})
 
     @inlineCallbacks
     def test_load_all(self):
         '''If data exists in redis, properties should contain that data'''
         store = yield self.create_store()
 
-        values = {
+        properties = {
             'foo': 'bar',
             'bar': 'foo',
         }
 
-        yield self.redis.hmset('testid', values)
+        yield self.redis.hmset('testid', properties)
 
-        yield store.load_all()
-        self.assertEqual(store.properties, values)
+        props = yield store.load_all('testid')
+        self.assertEqual(properties, props)
 
     @inlineCallbacks
     def test_load_property(self):
@@ -75,73 +67,43 @@ class TestBaseStore(JunebugTestBase):
 
         yield self.redis.hset('testid', 'foo', 'bar')
 
-        yield store.load_property('foo')
+        val = yield store.load_property('testid', 'foo')
 
-        self.assertEqual(store.properties['foo'], 'bar')
+        self.assertEqual(val, 'bar')
 
     @inlineCallbacks
     def test_load_property_empty(self):
         '''Loads None if property doesn't exist in redis'''
         store = yield self.create_store()
 
-        yield store.load_property('foo')
+        val = yield store.load_property('testid', 'foo')
 
-        self.assertEqual(store.properties['foo'], None)
+        self.assertEqual(val, None)
 
+
+class TestInboundMessageStore(JunebugTestBase):
     @inlineCallbacks
-    def test_set_property(self):
-        '''Set the property on the store properties'''
-        store = yield self.create_store()
-        yield store.set_property('foo', 'bar')
-        self.assertEqual(store.properties['foo'], 'bar')
-
-    @inlineCallbacks
-    def test_get_property(self):
-        '''Gets the value of the property from the store'''
-        store = yield self.create_store()
-        store.properties = {
-            'foo': 'bar',
-            'bar': 'foo',
-        }
-
-        self.assertEqual((yield store.get_property('foo')), 'bar')
-        self.assertEqual((yield store.get_property('bar')), 'foo')
-        self.assertEqual((yield store.get_property('baz')), None)
-
-    @inlineCallbacks
-    def test_from_id(self):
+    def create_store(self, ttl=60):
         redis = yield self.get_redis()
-        yield redis.hmset('testid', {
-            'foo': 'bar',
-            'bar': 'foo',
-        })
-        store = yield BaseStore.from_id('testid', redis, 60)
+        store = InboundMessageStore(redis, ttl)
+        returnValue(store)
 
-        self.assertEqual(store.id, 'testid')
-        self.assertEqual(store.ttl, 60)
-        self.assertEqual(store.properties, {
-            'foo': 'bar',
-            'bar': 'foo',
-            })
-
-
-class TestInboundMessage(JunebugTestBase):
     @inlineCallbacks
-    def test_from_vumi_message(self):
-        '''Creates an InboundMessage from a TransportUserMessage'''
+    def test_store_vumi_message(self):
+        '''Stores the vumi message.'''
+        store = yield self.create_store()
         vumi_msg = TransportUserMessage.send(to_addr='+213', content='foo')
-        redis = yield self.get_redis()
-        message = yield InboundMessage.from_vumi_message(vumi_msg, redis, 60)
-        self.assertEqual(vumi_msg.to_json(), message.properties['message'])
+        yield store.store_vumi_message(vumi_msg)
+        msg = yield self.redis.hget(vumi_msg.get('message_id'), 'message')
+        self.assertEqual(vumi_msg, TransportUserMessage.from_json(msg))
 
     @inlineCallbacks
-    def test_vumi_message_property(self):
+    def test_get(self):
         '''Returns a vumi message from the stored json'''
+        store = yield self.create_store()
         vumi_msg = TransportUserMessage.send(to_addr='+213', content='foo')
-        redis = yield self.get_redis()
-        message = yield InboundMessage.from_vumi_message(vumi_msg, redis, 60)
-        yield message.save_all()
+        yield self.redis.hset(
+            vumi_msg.get('message_id'), 'message', vumi_msg.to_json())
 
-        message = yield InboundMessage.from_id(
-            vumi_msg.get('message_id'), redis, 60)
-        self.assertEqual(message.vumi_message, vumi_msg)
+        message = yield store.load_vumi_message(vumi_msg.get('message_id'))
+        self.assertEqual(message, vumi_msg)


### PR DESCRIPTION
For inbound messages, we need to store the message so that we can construct a reply_to message. The message will be stored in redis with an expiry.