### PR TITLE
Store event urls

### DIFF
--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -65,6 +65,10 @@ def parse_arguments(args):
         '--inbound-message-ttl', '-ittl', dest='inbound_message_ttl', type=int,
         help='The maximum time allowed to reply to a message. Defaults to '
         '"60" seconds')
+    parser.add_argument(
+        '--outbound-message-ttl', '-ottl', dest='outbound_message_ttl',
+        type=int, help='The maximum time allowed for events to arrive for '
+        'messages. Defaults to 60*60*24*3 seconds or 3 days')
 
     return config_from_args(vars(parser.parse_args(args)))
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -68,7 +68,7 @@ def parse_arguments(args):
     parser.add_argument(
         '--outbound-message-ttl', '-ottl', dest='outbound_message_ttl',
         type=int, help='The maximum time allowed for events to arrive for '
-        'messages. Defaults to 60*60*24*3 seconds or 3 days')
+        'messages. Defaults to 60*60*24*2 seconds or 2 days')
 
     return config_from_args(vars(parser.parse_args(args)))
 

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -41,4 +41,4 @@ class JunebugConfig(Config):
 
     outbound_message_ttl = ConfigInt(
         "Maximum time allowed for events to arrive for messages",
-        default=60*60*24*2)
+        default=60 * 60 * 24 * 2)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -36,9 +36,9 @@ class JunebugConfig(Config):
         })
 
     inbound_message_ttl = ConfigInt(
-        "Maximum time allowed to reply to messages. Defaults to 60s",
+        "Maximum time allowed to reply to messages",
         default=60)
 
     outbound_message_ttl = ConfigInt(
-        "Maximum time allowed for events to arrive for messages. "
-        "Defaults to 2 days.", default=60 * 60 * 24 * 2)
+        "Maximum time allowed for events to arrive for messages",
+        default=60 * 60 * 24 * 2)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -36,9 +36,9 @@ class JunebugConfig(Config):
         })
 
     inbound_message_ttl = ConfigInt(
-        "Maximum time allowed to reply to messages",
+        "Maximum time allowed to reply to messages. Defaults to 60s",
         default=60)
 
     outbound_message_ttl = ConfigInt(
-        "Maximum time allowed for events to arrive for messages",
-        default=60 * 60 * 24 * 2)
+        "Maximum time allowed for events to arrive for messages. "
+        "Defaults to 2 days.", default=60 * 60 * 24 * 2)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -36,9 +36,9 @@ class JunebugConfig(Config):
         })
 
     inbound_message_ttl = ConfigInt(
-        "Maximum time allowed to reply to messages",
+        "Maximum time (in seconds) allowed to reply to messages",
         default=60)
 
     outbound_message_ttl = ConfigInt(
-        "Maximum time allowed for events to arrive for messages",
+        "Maximum time (in seconds) allowed for events to arrive for messages",
         default=60 * 60 * 24 * 2)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -41,4 +41,4 @@ class JunebugConfig(Config):
 
     outbound_message_ttl = ConfigInt(
         "Maximum time allowed for events to arrive for messages",
-        default=60*60*24*3)
+        default=60*60*24*2)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -38,3 +38,7 @@ class JunebugConfig(Config):
     inbound_message_ttl = ConfigInt(
         "Maximum time allowed to reply to messages",
         default=60)
+
+    outbound_message_ttl = ConfigInt(
+        "Maximum time allowed for events to arrive for messages",
+        default=60*60*24*3)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -129,7 +129,6 @@ class JunebugTestBase(TestCase):
             self.service, config)
 
         redis = yield self.persistencehelper.get_redis_manager()
-        message_sender = self.get_message_sender()
         self.api = JunebugApi(self.service, config)
         yield self.api.setup(redis, self.get_message_sender())
 

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -171,9 +171,9 @@ class TestCommandLine(JunebugTestBase):
         config = parse_arguments(['-amqpv', 'foo.bar'])
         self.assertEqual(config.amqp['vhost'], 'foo.bar')
 
-    def test_parse_arguments_ttl(self):
-        '''The ttl command line argument can be specified by
-        "--inbound-message-ttl" or "-ittl" and has a default value of "80"'''
+    def test_parse_arguments_inbound_ttl(self):
+        '''The inbound ttl command line argument can be specified by
+        "--inbound-message-ttl" or "-ittl" and has a default value of "60"'''
         config = parse_arguments([])
         self.assertEqual(config.inbound_message_ttl, 60)
 
@@ -182,6 +182,19 @@ class TestCommandLine(JunebugTestBase):
 
         config = parse_arguments(['-ittl', '80'])
         self.assertEqual(config.inbound_message_ttl, 80)
+
+    def test_parse_arguments_outbound_ttl(self):
+        '''The outbound ttl command line argument can be specified by
+        "--outbound-message-ttl" or "-ottl" and has a default value of 3 days
+        '''
+        config = parse_arguments([])
+        self.assertEqual(config.outbound_message_ttl, 60*60*24*3)
+
+        config = parse_arguments(['--outbound-message-ttl', '90'])
+        self.assertEqual(config.outbound_message_ttl, 90)
+
+        config = parse_arguments(['-ottl', '90'])
+        self.assertEqual(config.outbound_message_ttl, 90)
 
     def test_config_file(self):
         '''The config file command line argument can be specified by
@@ -205,6 +218,7 @@ class TestCommandLine(JunebugTestBase):
                     'password': 'nimda',
                 },
                 'inbound_message_ttl': 80,
+                'outbound_message_ttl': 90,
             }
         })
 
@@ -222,6 +236,7 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.amqp['username'], 'admin')
         self.assertEqual(config.amqp['password'], 'nimda')
         self.assertEqual(config.inbound_message_ttl, 80)
+        self.assertEqual(config.outbound_message_ttl, 90)
 
         config = parse_arguments(['-c', '/foo/bar.yaml'])
         self.assertEqual(config.interface, 'lolcathost')
@@ -237,6 +252,7 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.amqp['username'], 'admin')
         self.assertEqual(config.amqp['password'], 'nimda')
         self.assertEqual(config.inbound_message_ttl, 80)
+        self.assertEqual(config.outbound_message_ttl, 90)
 
     def test_config_file_overriding(self):
         '''Config file options are overriden by their corresponding command

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -185,10 +185,10 @@ class TestCommandLine(JunebugTestBase):
 
     def test_parse_arguments_outbound_ttl(self):
         '''The outbound ttl command line argument can be specified by
-        "--outbound-message-ttl" or "-ottl" and has a default value of 3 days
+        "--outbound-message-ttl" or "-ottl" and has a default value of 2 days
         '''
         config = parse_arguments([])
-        self.assertEqual(config.outbound_message_ttl, 60*60*24*3)
+        self.assertEqual(config.outbound_message_ttl, 60*60*24*2)
 
         config = parse_arguments(['--outbound-message-ttl', '90'])
         self.assertEqual(config.outbound_message_ttl, 90)


### PR DESCRIPTION
For outbound (MT) messages, we should store the mapping between the event url and the message id, using the OutboundMessageStore, so that we know where to send events to.