### PR TITLE
Send events to per-message event urls

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -192,7 +192,8 @@ class Channel(object):
             'transport_name': self.id,
             'mo_message_url': self._properties['mo_url'],
             'redis_manager': self.config.redis,
-            'ttl': self.config.inbound_message_ttl,
+            'inbound_ttl': self.config.inbound_message_ttl,
+            'outbound_ttl': self.config.outbound_message_ttl,
         }
 
     @property

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -8,7 +8,7 @@ from vumi.message import TransportUserMessage
 from junebug.channel import Channel
 from junebug.utils import api_from_message
 from junebug.tests.helpers import JunebugTestBase
-from junebug.tests.utils import conjoin, omit
+from junebug.utils import conjoin, omit
 
 
 class TestJunebugApi(JunebugTestBase):

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -6,6 +6,7 @@ from twisted.web import http
 from vumi.message import TransportUserMessage
 
 from junebug.channel import Channel
+from junebug.utils import api_from_message
 from junebug.tests.helpers import JunebugTestBase
 from junebug.tests.utils import conjoin, omit
 
@@ -366,7 +367,7 @@ class TestJunebugApi(JunebugTestBase):
 
         yield self.api.inbounds.store_vumi_message('test-channel', in_msg)
         expected = in_msg.reply(content='testcontent')
-        expected = Channel.api_from_message(expected)
+        expected = api_from_message(expected)
 
         resp = yield self.post('/channels/test-channel/messages/', {
             'reply_to': in_msg['message_id'],

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -8,7 +8,7 @@ from junebug.workers import MessageForwardingWorker
 from junebug.channel import (
     Channel, ChannelNotFound, InvalidChannelType, MessageNotFound)
 from junebug.tests.helpers import JunebugTestBase
-from junebug.tests.utils import conjoin
+from junebug.utils import conjoin
 
 
 class TestChannel(JunebugTestBase):

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -3,6 +3,7 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.message import TransportUserMessage
 from vumi.transports.telnet import TelnetServerTransport
 
+from junebug.utils import api_from_message
 from junebug.workers import MessageForwardingWorker
 from junebug.channel import (
     Channel, ChannelNotFound, InvalidChannelType, MessageNotFound)
@@ -275,7 +276,7 @@ class TestChannel(JunebugTestBase):
             })
 
         expected = in_msg.reply(content='testcontent')
-        expected = conjoin(Channel.api_from_message(expected), {
+        expected = conjoin(api_from_message(expected), {
             'timestamp': msg['timestamp'],
             'message_id': msg['message_id']
         })
@@ -284,7 +285,7 @@ class TestChannel(JunebugTestBase):
 
         [dispatched] = self.get_dispatched_messages('channel-id.outbound')
         self.assertEqual(msg['message_id'], dispatched['message_id'])
-        self.assertEqual(Channel.api_from_message(dispatched), expected)
+        self.assertEqual(api_from_message(dispatched), expected)
 
     @inlineCallbacks
     def test_send_reply_message_inbound_not_found(self):
@@ -298,67 +299,3 @@ class TestChannel(JunebugTestBase):
                 'reply_to': 'i-do-not-exist',
                 'content': 'testcontent',
             }), MessageNotFound)
-
-    @inlineCallbacks
-    def test_api_from_message(self):
-        '''The api from message function should take a vumi message, and
-        return a dict with the appropriate values'''
-        channel = yield self.create_channel(
-            self.service, self.redis, TelnetServerTransport, id='channel-id')
-        message = TransportUserMessage.send(
-            content=None, from_addr='+1234', to_addr='+5432',
-            transport_name='testtransport', continue_session=True,
-            helper_metadata={'voice': {}})
-        dct = channel.api_from_message(message)
-        [dct.pop(f) for f in ['timestamp', 'message_id']]
-        self.assertEqual(dct, {
-            'channel_data': {
-                'continue_session': True,
-                'voice': {},
-                },
-            'from': '+1234',
-            'to': '+5432',
-            'channel_id': 'testtransport',
-            'content': None,
-            'reply_to': None,
-            })
-
-    @inlineCallbacks
-    def test_message_from_api(self):
-        yield self.create_channel(
-            self.service, self.redis, TelnetServerTransport, id='channel-id')
-        msg = Channel.message_from_api(
-            'channel-id', {
-                'from': '+1234',
-                'content': None,
-                'channel_data': {
-                    'continue_session': True,
-                    'voice': {},
-                    },
-                })
-        msg = TransportUserMessage.send(**msg)
-        self.assertEqual(msg.get('continue_session'), True)
-        self.assertEqual(msg.get('helper_metadata'), {'voice': {}})
-        self.assertEqual(msg.get('from_addr'), '+1234')
-        self.assertEqual(msg.get('content'), None)
-
-    @inlineCallbacks
-    def test_message_from_api_reply(self):
-        yield self.create_channel(
-            self.service, self.redis, TelnetServerTransport, id='channel-id')
-
-        msg = Channel.message_from_api(
-            'channel-id', {
-                'reply_to': 1234,
-                'content': 'foo',
-                'channel_data': {
-                    'continue_session': True,
-                    'voice': {},
-                },
-            })
-
-        self.assertFalse('to_addr' in msg)
-        self.assertFalse('from_addr' in msg)
-        self.assertEqual(msg['continue_session'], True)
-        self.assertEqual(msg['helper_metadata'], {'voice': {}})
-        self.assertEqual(msg['content'], 'foo')

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -79,7 +79,8 @@ class TestChannel(JunebugTestBase):
             'transport_name': channel.id,
             'mo_message_url': 'http://foo.org',
             'redis_manager': channel.config.redis,
-            'ttl': 60,
+            'inbound_ttl': channel.config.inbound_message_ttl,
+            'outbound_ttl': channel.config.outbound_message_ttl,
         })
 
     @inlineCallbacks

--- a/junebug/tests/test_utils.py
+++ b/junebug/tests/test_utils.py
@@ -8,7 +8,10 @@ import treq
 from klein import Klein
 
 from junebug.tests.utils import ToyServer
-from junebug.utils import response, json_body
+from junebug.utils import (
+    response, json_body, message_from_api, api_from_message)
+
+from vumi.message import TransportUserMessage
 
 
 class TestUtils(TestCase):
@@ -71,3 +74,57 @@ class TestUtils(TestCase):
             data=json.dumps({'foo': 23}))
 
         self.assertEqual(bodies, [{'foo': 23}])
+
+    def test_api_from_message(self):
+        '''The api from message function should take a vumi message, and
+        return a dict with the appropriate values'''
+        message = TransportUserMessage.send(
+            content=None, from_addr='+1234', to_addr='+5432',
+            transport_name='testtransport', continue_session=True,
+            helper_metadata={'voice': {}})
+        dct = api_from_message(message)
+        [dct.pop(f) for f in ['timestamp', 'message_id']]
+        self.assertEqual(dct, {
+            'channel_data': {
+                'continue_session': True,
+                'voice': {},
+                },
+            'from': '+1234',
+            'to': '+5432',
+            'channel_id': 'testtransport',
+            'content': None,
+            'reply_to': None,
+            })
+
+    def test_message_from_api(self):
+        msg = message_from_api(
+            'channel-id', {
+                'from': '+1234',
+                'content': None,
+                'channel_data': {
+                    'continue_session': True,
+                    'voice': {},
+                    },
+                })
+        msg = TransportUserMessage.send(**msg)
+        self.assertEqual(msg.get('continue_session'), True)
+        self.assertEqual(msg.get('helper_metadata'), {'voice': {}})
+        self.assertEqual(msg.get('from_addr'), '+1234')
+        self.assertEqual(msg.get('content'), None)
+
+    def test_message_from_api_reply(self):
+        msg = message_from_api(
+            'channel-id', {
+                'reply_to': 1234,
+                'content': 'foo',
+                'channel_data': {
+                    'continue_session': True,
+                    'voice': {},
+                },
+            })
+
+        self.assertFalse('to_addr' in msg)
+        self.assertFalse('from_addr' in msg)
+        self.assertEqual(msg['continue_session'], True)
+        self.assertEqual(msg['helper_metadata'], {'voice': {}})
+        self.assertEqual(msg['content'], 'foo')

--- a/junebug/tests/test_utils.py
+++ b/junebug/tests/test_utils.py
@@ -9,7 +9,7 @@ from klein import Klein
 
 from junebug.tests.utils import ToyServer
 from junebug.utils import (
-    response, json_body, message_from_api, api_from_message)
+    response, json_body, conjoin, omit, message_from_api, api_from_message)
 
 from vumi.message import TransportUserMessage
 
@@ -74,6 +74,53 @@ class TestUtils(TestCase):
             data=json.dumps({'foo': 23}))
 
         self.assertEqual(bodies, [{'foo': 23}])
+
+    def test_conjoin(self):
+        a = {
+            'foo': 21,
+            'bar': 23,
+        }
+
+        b = {
+            'bar': 'baz',
+            'quux': 'corge',
+        }
+
+        self.assertEqual(conjoin(a, b), {
+            'foo': 21,
+            'bar': 'baz',
+            'quux': 'corge',
+        })
+
+        self.assertEqual(a, {
+            'foo': 21,
+            'bar': 23,
+        })
+
+        self.assertEqual(b, {
+            'bar': 'baz',
+            'quux': 'corge',
+        })
+
+    def test_omit(self):
+        coll = {
+            'foo': 'bar',
+            'baz': 'quux',
+            'corge': 'grault',
+            'garply': 'waldo',
+        }
+
+        self.assertEqual(omit(coll, 'foo', 'garply'), {
+            'baz': 'quux',
+            'corge': 'grault',
+        })
+
+        self.assertEqual(coll, {
+            'foo': 'bar',
+            'baz': 'quux',
+            'corge': 'grault',
+            'garply': 'waldo',
+        })
 
     def test_api_from_message(self):
         '''The api from message function should take a vumi message, and

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -299,7 +299,7 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.assert_was_logged('test-error-response')
 
     @inlineCallbacks
-    def test_forward_nack_no_message(self):
+    def test_forward_dr_no_message(self):
         self.patch_logger()
 
         event = TransportEvent(

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -179,6 +179,23 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.assert_was_logged('test-error-response')
 
     @inlineCallbacks
+    def test_forward_ack_no_message(self):
+        self.patch_logger()
+
+        event = TransportEvent(
+            event_type='ack',
+            user_message_id='msg-21',
+            sent_message_id='msg-21',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        yield self.worker.consume_ack(event)
+
+        self.assertEqual(self.logging_api.requests, [])
+
+        self.assert_was_logged(
+            "Outbound mesage not found for event %r" % (event,))
+
+    @inlineCallbacks
     def test_forward_nack(self):
         event = TransportEvent(
             event_type='nack',
@@ -220,6 +237,23 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.assert_was_logged(repr(event))
         self.assert_was_logged('500')
         self.assert_was_logged('test-error-response')
+
+    @inlineCallbacks
+    def test_forward_nack_no_message(self):
+        self.patch_logger()
+
+        event = TransportEvent(
+            event_type='nack',
+            user_message_id='msg-21',
+            nack_reason='too many foos',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        yield self.worker.consume_nack(event)
+
+        self.assertEqual(self.logging_api.requests, [])
+
+        self.assert_was_logged(
+            "Outbound mesage not found for event %r" % (event,))
 
     @inlineCallbacks
     def test_forward_dr(self):
@@ -265,6 +299,23 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.assert_was_logged('test-error-response')
 
     @inlineCallbacks
+    def test_forward_nack_no_message(self):
+        self.patch_logger()
+
+        event = TransportEvent(
+            event_type='delivery_report',
+            user_message_id='msg-21',
+            delivery_status='pending',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        yield self.worker.consume_delivery_report(event)
+
+        self.assertEqual(self.logging_api.requests, [])
+
+        self.assert_was_logged(
+            "Outbound mesage not found for event %r" % (event,))
+
+    @inlineCallbacks
     def test_forward_event_bad_event(self):
         self.patch_logger()
 
@@ -282,5 +333,4 @@ class TestMessageForwardingWorker(JunebugTestBase):
         yield self.worker.forward_event(event)
 
         self.assertEqual(self.logging_api.requests, [])
-
         self.assert_was_logged("Discarding unrecognised event %r" % (event,))

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -1,15 +1,18 @@
-import treq
 import json
+
+import treq
 from klein import Klein
+
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web.client import HTTPConnectionPool
 from twisted.web.server import Site
+
 from vumi.application.tests.helpers import ApplicationHelper
-from vumi.message import TransportUserMessage
+from vumi.message import TransportUserMessage, TransportEvent
 from vumi.tests.helpers import PersistenceHelper
 
-from junebug.utils import conjoin
+from junebug.utils import conjoin, api_from_event
 from junebug.workers import MessageForwardingWorker
 from junebug.tests.helpers import JunebugTestBase
 
@@ -49,31 +52,38 @@ class TestMessageForwardingWorker(JunebugTestBase):
         addr = port.getHost()
         self.url = "http://%s:%s" % (addr.host, addr.port)
 
-        persistencehelper = PersistenceHelper()
-        yield persistencehelper.setup()
-        self.addCleanup(persistencehelper.cleanup)
-
-        app_config = persistencehelper.mk_config({
-            'transport_name': 'testtransport',
-            'mo_message_url': self.url.decode('utf-8'),
-        })
-
-        self.worker = yield self.get_worker(app_config)
-
+        self.worker = yield self.get_worker()
         connection_pool = HTTPConnectionPool(reactor, persistent=False)
         treq._utils.set_global_pool(connection_pool)
 
     @inlineCallbacks
-    def get_worker(self, config):
+    def get_worker(self, config=None):
         '''Get a new MessageForwardingWorker with the provided config'''
+        if config is None:
+            config = {}
+
         app_helper = ApplicationHelper(MessageForwardingWorker)
         yield app_helper.setup()
         self.addCleanup(app_helper.cleanup)
-        worker = yield app_helper.get_application(conjoin(config, {
+
+        persistencehelper = PersistenceHelper()
+        yield persistencehelper.setup()
+        self.addCleanup(persistencehelper.cleanup)
+
+        config = conjoin(persistencehelper.mk_config({
+            'transport_name': 'testtransport',
+            'mo_message_url': self.url.decode('utf-8'),
             'inbound_ttl': 60,
             'outbound_ttl': 60 * 60 * 24 * 2,
-        }))
+        }), config)
+
+        worker = yield app_helper.get_application(config)
         returnValue(worker)
+
+    @inlineCallbacks
+    def test_channel_id(self):
+        worker = yield self.get_worker({'transport_name': 'foo'})
+        self.assertEqual(worker.channel_id, 'foo')
 
     @inlineCallbacks
     def test_send_message(self):
@@ -104,10 +114,10 @@ class TestMessageForwardingWorker(JunebugTestBase):
         yield self.worker.consume_user_message(msg)
 
         self.assertTrue(any(
-            '"content": "testcontent"' in l.getMessage()
+            "'content': 'testcontent'" in l.getMessage()
             for l in self.logging_handler.buffer))
         self.assertTrue(any(
-            '"to": "+1234"' in l.getMessage()
+            "'to': '+1234'" in l.getMessage()
             for l in self.logging_handler.buffer))
         self.assertTrue(any(
             '500' in l.getMessage()
@@ -127,3 +137,99 @@ class TestMessageForwardingWorker(JunebugTestBase):
             self.worker.config['transport_name'], msg['message_id'])
         msg_json = yield redis.hget(key, 'message')
         self.assertEqual(TransportUserMessage.from_json(msg_json), msg)
+
+    @inlineCallbacks
+    def test_forward_ack(self):
+        event = TransportEvent(
+            event_type='ack',
+            user_message_id='msg-21',
+            sent_message_id='msg-21',
+            timestamp='2015-09-22 15:39:44.827794',
+        )
+
+        yield self.worker.outbounds.store_event_url(
+            self.worker.channel_id, 'msg-21', self.url)
+
+        yield self.worker.consume_ack(event)
+
+        [request] = self.logging_api.requests
+        req = request['request']
+        body = json.loads(request['body'])
+
+        self.assertEqual(
+            req.requestHeaders.getRawHeaders('content-type'),
+            ['application/json'])
+
+        self.assertEqual(req.method, 'POST')
+        self.assertEqual(body, api_from_event(self.worker.channel_id, event))
+
+    @inlineCallbacks
+    def test_forward_nack(self):
+        event = TransportEvent(
+            event_type='nack',
+            user_message_id='msg-21',
+            nack_reason='too many foos',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        yield self.worker.outbounds.store_event_url(
+            self.worker.channel_id, 'msg-21', self.url)
+
+        yield self.worker.consume_nack(event)
+
+        [request] = self.logging_api.requests
+        req = request['request']
+        body = json.loads(request['body'])
+
+        self.assertEqual(
+            req.requestHeaders.getRawHeaders('content-type'),
+            ['application/json'])
+
+        self.assertEqual(req.method, 'POST')
+        self.assertEqual(body, api_from_event(self.worker.channel_id, event))
+
+    @inlineCallbacks
+    def test_forward_dr(self):
+        event = TransportEvent(
+            event_type='delivery_report',
+            user_message_id='msg-21',
+            delivery_status='pending',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        yield self.worker.outbounds.store_event_url(
+            self.worker.channel_id, 'msg-21', self.url)
+
+        yield self.worker.consume_delivery_report(event)
+
+        [request] = self.logging_api.requests
+        req = request['request']
+        body = json.loads(request['body'])
+
+        self.assertEqual(
+            req.requestHeaders.getRawHeaders('content-type'),
+            ['application/json'])
+
+        self.assertEqual(req.method, 'POST')
+        self.assertEqual(body, api_from_event(self.worker.channel_id, event))
+
+    @inlineCallbacks
+    def test_forward_event_bad_event(self):
+        self.patch_logger()
+
+        event = TransportEvent(
+            event_type='ack',
+            user_message_id='msg-21',
+            sent_message_id='msg-21',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        event['event_type'] = 'bad'
+
+        yield self.worker.outbounds.store_event_url(
+            self.worker.channel_id, 'msg-21', self.url)
+
+        yield self.worker.forward_event(event)
+
+        self.assertEqual(self.logging_api.requests, [])
+
+        self.assertTrue(any(
+            "Discarding unrecognised event %r" % (event,) in log.getMessage()
+            for log in self.logging_handler.buffer))

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -207,9 +207,9 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.patch_logger()
 
         event = TransportEvent(
-            event_type='ack',
+            event_type='nack',
             user_message_id='msg-21',
-            sent_message_id='msg-21',
+            nack_reason='too many foos',
             timestamp='2015-09-22 15:39:44.827794')
 
         yield self.worker.outbounds.store_event_url(

--- a/junebug/tests/utils.py
+++ b/junebug/tests/utils.py
@@ -26,14 +26,3 @@ class ToyServer(object):
         yield server.setup(app)
         test.addCleanup(server.teardown)
         returnValue(server)
-
-
-def conjoin(a, b):
-    result = {}
-    result.update(a)
-    result.update(b)
-    return result
-
-
-def omit(collection, *fields):
-    return dict((k, v) for k, v in collection.iteritems() if k not in fields)

--- a/junebug/utils.py
+++ b/junebug/utils.py
@@ -24,3 +24,44 @@ def json_body(fn):
         return fn(api, req, body, *a, **kw)
 
     return wrapper
+
+
+def api_from_message(msg):
+    ret = {}
+    ret['to'] = msg['to_addr']
+    ret['from'] = msg['from_addr']
+    ret['message_id'] = msg['message_id']
+    ret['channel_id'] = msg['transport_name']
+    ret['timestamp'] = msg['timestamp']
+    ret['reply_to'] = msg['in_reply_to']
+    ret['content'] = msg['content']
+    ret['channel_data'] = msg['helper_metadata']
+
+    if msg.get('continue_session') is not None:
+        ret['channel_data']['continue_session'] = msg['continue_session']
+    if msg.get('session_event') is not None:
+        ret['channel_data']['session_event'] = msg['session_event']
+
+    return ret
+
+
+def message_from_api(channel_id, msg):
+    ret = {}
+
+    if 'reply_to' not in msg:
+        ret['to_addr'] = msg.get('to')
+        ret['from_addr'] = msg.get('from')
+
+    ret['content'] = msg['content']
+    ret['transport_name'] = channel_id
+
+    channel_data = msg.get('channel_data', {})
+    if channel_data.get('continue_session') is not None:
+        ret['continue_session'] = channel_data.pop('continue_session')
+
+    if channel_data.get('session_event') is not None:
+        ret['session_event'] = channel_data.pop('session_event')
+
+    ret['helper_metadata'] = channel_data
+    ret['transport_name'] = channel_id
+    return ret

--- a/junebug/utils.py
+++ b/junebug/utils.py
@@ -26,6 +26,17 @@ def json_body(fn):
     return wrapper
 
 
+def conjoin(a, b):
+    result = {}
+    result.update(a)
+    result.update(b)
+    return result
+
+
+def omit(collection, *fields):
+    return dict((k, v) for k, v in collection.iteritems() if k not in fields)
+
+
 def api_from_message(msg):
     ret = {}
     ret['to'] = msg['to_addr']

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -83,7 +83,7 @@ class MessageForwardingWorker(ApplicationWorker):
         if request_failed(resp):
             logging.exception(
                 'Error sending event, received HTTP code %r with body %r. '
-                'Event: %r' % (resp.code, (yield resp.content()), msg))
+                'Event: %r' % (resp.code, (yield resp.content()), event))
 
     def consume_ack(self, event):
         return self.forward_event(event)

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -7,7 +7,7 @@ from vumi.config import ConfigDict, ConfigInt, ConfigText
 from vumi.message import JSONMessageEncoder
 from vumi.persist.txredis_manager import TxRedisManager
 
-from junebug.channel import Channel
+from junebug.utils import api_from_message
 from junebug.stores import InboundMessageStore
 
 
@@ -51,7 +51,7 @@ class MessageForwardingWorker(ApplicationWorker):
             'Content-Type': 'application/json',
         }
         msg = json.dumps(
-            Channel.api_from_message(message), cls=JSONMessageEncoder)
+            api_from_message(message), cls=JSONMessageEncoder)
         resp = yield treq.post(url, data=msg, headers=headers)
         if resp.code < 200 or resp.code >= 300:
             logging.exception(

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -3,7 +3,7 @@ import logging
 
 import treq
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from vumi.application.base import ApplicationConfig, ApplicationWorker
 from vumi.config import ConfigDict, ConfigInt, ConfigText


### PR DESCRIPTION
#30 will allow us to store the per-message event urls given to the api when sending a message. This ticket is for fetching these stored event urls in `MessageForwardingWorker` when we consume an event, and sending the event to the url.