### PR TITLE
Set and document ttls

### DIFF
--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -132,9 +132,13 @@ Messages
        the uuid of the message being replied to if this is a response to a
        previous message. Important for session-based transports like USSD.
        Optional. Only one of ``to`` or ``reply_to`` may be specified.
+       Defaults settings allow 10 minutes to reply to a message, after which
+       an error will be returned.
    :param str event_url:
        URL to call for status events (e.g. acknowledgements and
-       delivery reports) related to this message.
+       delivery reports) related to this message. Default settings allow for
+       2 days for events to arrive, after which they will no longer be
+       forwarded.
    :param int priority:
        Delivery priority from 1 to 5. Higher priority messages are delivered first.
        If omitted, priority is 1.
@@ -218,6 +222,8 @@ format:
 
 Events are posted to the message’s ``event_url`` after the message is
 submitted to the provider, and when delivery reports are received.
+Default settings allow events to arrive for up to 2 days; any further events
+will not be forwarded.
 
 **Request example**:
 

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -136,7 +136,7 @@ Messages
        an error will be returned.
    :param str event_url:
        URL to call for status events (e.g. acknowledgements and
-       delivery reports) related to this message. Default settings allow for
+       delivery reports) related to this message. The default settings allow
        2 days for events to arrive, after which they will no longer be
        forwarded.
    :param int priority:
@@ -222,8 +222,8 @@ format:
 
 Events are posted to the message’s ``event_url`` after the message is
 submitted to the provider, and when delivery reports are received.
-Default settings allow events to arrive for up to 2 days; any further events
-will not be forwarded.
+The default settings allow events to arrive for up to 2 days; any further
+events will not be forwarded.
 
 **Request example**:
 

--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -132,7 +132,7 @@ Messages
        the uuid of the message being replied to if this is a response to a
        previous message. Important for session-based transports like USSD.
        Optional. Only one of ``to`` or ``reply_to`` may be specified.
-       Defaults settings allow 10 minutes to reply to a message, after which
+       The default settings allow 10 minutes to reply to a message, after which
        an error will be returned.
    :param str event_url:
        URL to call for status events (e.g. acknowledgements and

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -63,12 +63,12 @@ def parse_arguments(args):
         help='The password to use for the amqp auth. Defaults to "guest"')
     parser.add_argument(
         '--inbound-message-ttl', '-ittl', dest='inbound_message_ttl', type=int,
-        help='The maximum time allowed to reply to a message. Defaults to '
-        '60*10 seconds or 10 minutes')
+        help='The maximum time allowed to reply to a message (in seconds).'
+        'Defaults to 600 seconds (10 minutes).')
     parser.add_argument(
         '--outbound-message-ttl', '-ottl', dest='outbound_message_ttl',
         type=int, help='The maximum time allowed for events to arrive for '
-        'messages. Defaults to 60*60*24*2 seconds or 2 days')
+        'messages (in seconds). Defaults to 172800 seconds (2 days)')
 
     return config_from_args(vars(parser.parse_args(args)))
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -64,7 +64,7 @@ def parse_arguments(args):
     parser.add_argument(
         '--inbound-message-ttl', '-ittl', dest='inbound_message_ttl', type=int,
         help='The maximum time allowed to reply to a message. Defaults to '
-        '"60" seconds')
+        '60*10 seconds or 10 minutes')
     parser.add_argument(
         '--outbound-message-ttl', '-ottl', dest='outbound_message_ttl',
         type=int, help='The maximum time allowed for events to arrive for '

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -37,7 +37,7 @@ class JunebugConfig(Config):
 
     inbound_message_ttl = ConfigInt(
         "Maximum time (in seconds) allowed to reply to messages",
-        default=60)
+        default=60 * 10)
 
     outbound_message_ttl = ConfigInt(
         "Maximum time (in seconds) allowed for events to arrive for messages",

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -173,9 +173,10 @@ class TestCommandLine(JunebugTestBase):
 
     def test_parse_arguments_inbound_ttl(self):
         '''The inbound ttl command line argument can be specified by
-        "--inbound-message-ttl" or "-ittl" and has a default value of "60"'''
+        "--inbound-message-ttl" or "-ittl" and has a default value of
+        10 minutes'''
         config = parse_arguments([])
-        self.assertEqual(config.inbound_message_ttl, 60)
+        self.assertEqual(config.inbound_message_ttl, 60 * 10)
 
         config = parse_arguments(['--inbound-message-ttl', '80'])
         self.assertEqual(config.inbound_message_ttl, 80)


### PR DESCRIPTION
For storing event URLs, the default should be 2 days, for replies, the default should be 10 minutes. These defaults and their implications should be documented, and the defaults should be set correctly.