### PR TITLE
Fix message forwarding worker to ignore events without event urls

### DIFF
--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -205,9 +205,6 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         self.assertEqual(self.logging_api.requests, [])
 
-        self.assert_was_logged(
-            "Outbound mesage not found for event %r" % (event,))
-
     @inlineCallbacks
     def test_forward_nack(self):
         event = TransportEvent(
@@ -261,9 +258,6 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         self.assertEqual(self.logging_api.requests, [])
 
-        self.assert_was_logged(
-            "Outbound mesage not found for event %r" % (event,))
-
     @inlineCallbacks
     def test_forward_dr(self):
         event = TransportEvent(
@@ -316,9 +310,6 @@ class TestMessageForwardingWorker(JunebugTestBase):
         yield self.worker.consume_delivery_report(event)
 
         self.assertEqual(self.logging_api.requests, [])
-
-        self.assert_was_logged(
-            "Outbound mesage not found for event %r" % (event,))
 
     @inlineCallbacks
     def test_forward_event_bad_event(self):

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -77,8 +77,6 @@ class MessageForwardingWorker(ApplicationWorker):
         url = yield self._get_event_url(event)
 
         if url is None:
-            logging.exception(
-                "Outbound message not found for event %r" % (event,))
             return
 
         msg = api_from_event(self.channel_id, event)


### PR DESCRIPTION
At the moment, giving event urls is optional when sending a message, yet we log an error in the message forwarding worker if no event url is found.