### PR TITLE
Store outbound message event urls before publish outbound messages

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -222,14 +222,11 @@ class JunebugApi(object):
 
         if 'to' in body:
             msg = yield Channel.send_message(
-                channel_id, self.message_sender, body)
+                channel_id, self.message_sender, self.outbounds, body)
         else:
             msg = yield Channel.send_reply_message(
-                channel_id, self.message_sender, self.inbounds, body)
-
-        if 'event_url' in body:
-            yield self.outbounds.store_event_url(
-                channel_id, msg['message_id'], body['event_url'])
+                channel_id, self.message_sender, self.outbounds,
+                self.inbounds, body)
 
         returnValue(response(request, 'message sent', msg))
 

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -135,6 +135,7 @@ class JunebugTestBase(TestCase):
         self.config = self.api.config
         self.redis = self.api.redis
         self.inbounds = self.api.inbounds
+        self.outbounds = self.api.outbounds
         self.message_sender = self.api.message_sender
 
         port = reactor.listenTCP(

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -317,6 +317,7 @@ class TestJunebugApi(JunebugTestBase):
             'test-channel', message['message_id'])
         self.assertEqual(event_url, None)
 
+    timeout = 1
     @inlineCallbacks
     def test_send_message_event_url(self):
         '''Sending a message with a specified event url should store the event

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -317,7 +317,6 @@ class TestJunebugApi(JunebugTestBase):
             'test-channel', message['message_id'])
         self.assertEqual(event_url, None)
 
-    timeout = 1
     @inlineCallbacks
     def test_send_message_event_url(self):
         '''Sending a message with a specified event url should store the event


### PR DESCRIPTION
At the moment we publish first and then store, which can lead to race conditions where have not yet stored the message when handling events for the outbound message.