### PR TITLE
Character limits

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -220,11 +220,10 @@ class JunebugApi(object):
 
         if 'to' in body:
             msg = yield channel.send_message(
-                channel_id, self.message_sender, self.outbounds, body)
+                self.message_sender, self.outbounds, body)
         else:
             msg = yield channel.send_reply_message(
-                channel_id, self.message_sender, self.outbounds,
-                self.inbounds, body)
+                self.message_sender, self.outbounds, self.inbounds, body)
 
         returnValue(response(request, 'message sent', msg))
 

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -218,15 +218,6 @@ class JunebugApi(object):
         channel = yield Channel.from_id(
             self.redis, self.config, channel_id, self.service)
 
-        if (channel.character_limit is not None
-                and len(body['content']) > channel.character_limit):
-            raise ApiUsageError(
-                'Message content %r is of length %d, which is greater than the'
-                ' character limit of %d' % (
-                    body['content'], len(body['content']),
-                    channel.character_limit)
-                )
-
         if 'to' in body:
             msg = yield channel.send_message(
                 channel_id, self.message_sender, self.outbounds, body)

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -228,10 +228,10 @@ class JunebugApi(object):
                 )
 
         if 'to' in body:
-            msg = yield Channel.send_message(
+            msg = yield channel.send_message(
                 channel_id, self.message_sender, self.outbounds, body)
         else:
-            msg = yield Channel.send_reply_message(
+            msg = yield channel.send_reply_message(
                 channel_id, self.message_sender, self.outbounds,
                 self.inbounds, body)
 

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -73,6 +73,10 @@ class Channel(object):
     def application_id(self):
         return self.APPLICATION_ID % (self.id,)
 
+    @property
+    def character_limit(self):
+        return self._properties.get('character_limit')
+
     def start(self, service, transport_worker=None):
         '''Starts the relevant workers for the channel. ``service`` is the
         parent of under which the workers should be started.'''

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -155,19 +155,17 @@ class Channel(object):
         channels = yield redis.smembers('channels')
         returnValue(channels)
 
-    @classmethod
     @inlineCallbacks
-    def send_message(cls, id, sender, outbounds, msg):
+    def send_message(self, id, sender, outbounds, msg):
         '''Sends a message.'''
         event_url = msg.get('event_url')
         msg = message_from_api(id, msg)
         msg = TransportUserMessage.send(**msg)
-        msg = yield cls._send_message(id, sender, outbounds, event_url, msg)
+        msg = yield self._send_message(id, sender, outbounds, event_url, msg)
         returnValue(api_from_message(msg))
 
-    @classmethod
     @inlineCallbacks
-    def send_reply_message(cls, id, sender, outbounds, inbounds, msg):
+    def send_reply_message(self, id, sender, outbounds, inbounds, msg):
         '''Sends a reply message.'''
         in_msg = yield inbounds.load_vumi_message(id, msg['reply_to'])
 
@@ -178,7 +176,7 @@ class Channel(object):
         event_url = msg.get('event_url')
         msg = message_from_api(id, msg)
         msg = in_msg.reply(**msg)
-        msg = yield cls._send_message(id, sender, outbounds, event_url, msg)
+        msg = yield self._send_message(id, sender, outbounds, event_url, msg)
         returnValue(api_from_message(msg))
 
     @property
@@ -268,12 +266,11 @@ class Channel(object):
         else:
             return data
 
-    @classmethod
     @inlineCallbacks
-    def _send_message(cls, id, sender, outbounds, event_url, msg):
+    def _send_message(self, id, sender, outbounds, event_url, msg):
         if event_url is not None:
             yield outbounds.store_event_url(id, msg['message_id'], event_url)
 
-        queue = cls.OUTBOUND_QUEUE % (id,)
+        queue = self.OUTBOUND_QUEUE % (id,)
         msg = yield sender.send_message(msg, routing_key=queue)
         returnValue(msg)

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -506,13 +506,13 @@ class TestJunebugApi(JunebugTestBase):
             'to': '+1234', 'content': 'Over the character limit.',
             'from': None})
         yield self.assert_response(
-            resp, http.BAD_REQUEST, 'api usage error', {
+            resp, http.BAD_REQUEST, 'message too long', {
                 'errors': [{
                     'message':
                         "Message content u'Over the character limit.' "
                         "is of length 25, which is greater than the character "
                         "limit of 10",
-                    'type': 'ApiUsageError',
+                    'type': 'MessageTooLong',
                 }],
             })
 

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -254,9 +254,9 @@ class TestChannel(JunebugTestBase):
     def test_send_message(self):
         '''The send_message function should place the message on the correct
         queue'''
-        yield self.create_channel(
+        channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
-        msg = yield Channel.send_message(
+        msg = yield channel.send_message(
             'channel-id', self.message_sender, self.outbounds, {
                 'from': '+1234',
                 'content': 'testcontent',
@@ -273,10 +273,10 @@ class TestChannel(JunebugTestBase):
     def test_send_message_event_url(self):
         '''Sending a message with a specified event url should store the event
         url for sending events in the future'''
-        yield self.create_channel(
+        channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
-        msg = yield Channel.send_message(
+        msg = yield channel.send_message(
             'channel-id', self.message_sender, self.outbounds, {
                 'from': '+1234',
                 'content': 'testcontent',
@@ -292,7 +292,7 @@ class TestChannel(JunebugTestBase):
     def test_send_reply_message(self):
         '''send_reply_message should place the correct reply message on the
         correct queue'''
-        yield self.create_channel(
+        channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
         in_msg = TransportUserMessage(
@@ -304,7 +304,7 @@ class TestChannel(JunebugTestBase):
 
         yield self.api.inbounds.store_vumi_message('channel-id', in_msg)
 
-        msg = yield Channel.send_reply_message(
+        msg = yield channel.send_reply_message(
             'channel-id', self.message_sender, self.outbounds, self.inbounds, {
                 'reply_to': in_msg['message_id'],
                 'content': 'testcontent',
@@ -326,10 +326,10 @@ class TestChannel(JunebugTestBase):
     def test_send_reply_message_inbound_not_found(self):
         '''send_reply_message should raise an error if the inbound message is
         not found'''
-        yield self.create_channel(
+        channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
-        self.assertFailure(Channel.send_reply_message(
+        self.assertFailure(channel.send_reply_message(
             'channel-id', self.message_sender, self.outbounds, self.inbounds, {
                 'reply_to': 'i-do-not-exist',
                 'content': 'testcontent',
@@ -339,7 +339,7 @@ class TestChannel(JunebugTestBase):
     def test_send_reply_message_event_url(self):
         '''Sending a message with a specified event url should store the event
         url for sending events in the future'''
-        yield self.create_channel(
+        channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
         in_msg = TransportUserMessage(
@@ -351,7 +351,7 @@ class TestChannel(JunebugTestBase):
 
         yield self.api.inbounds.store_vumi_message('channel-id', in_msg)
 
-        msg = yield Channel.send_reply_message(
+        msg = yield channel.send_reply_message(
             'channel-id', self.message_sender, self.outbounds, self.inbounds, {
                 'reply_to': in_msg['message_id'],
                 'content': 'testcontent',

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -83,6 +83,22 @@ class TestChannel(JunebugTestBase):
         })
 
     @inlineCallbacks
+    def test_channel_character_limit(self):
+        '''`character_limit` parameter should return the character limit, or
+        `None` if no character limit was specified'''
+        properties_limit = self.create_channel_properties(character_limit=100)
+        properties_no_limit = self.create_channel_properties()
+
+        channel_limit = yield self.create_channel(
+            self.service, self.redis, TelnetServerTransport, properties_limit)
+        channel_no_limit = yield self.create_channel(
+            self.service, self.redis, TelnetServerTransport,
+            properties_no_limit)
+
+        self.assertEqual(channel_limit.character_limit, 100)
+        self.assertEqual(channel_no_limit.character_limit, None)
+
+    @inlineCallbacks
     def test_create_channel_invalid_type(self):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -257,7 +257,7 @@ class TestChannel(JunebugTestBase):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
         msg = yield channel.send_message(
-            'channel-id', self.message_sender, self.outbounds, {
+            self.message_sender, self.outbounds, {
                 'from': '+1234',
                 'content': 'testcontent',
             })
@@ -277,7 +277,7 @@ class TestChannel(JunebugTestBase):
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
         msg = yield channel.send_message(
-            'channel-id', self.message_sender, self.outbounds, {
+            self.message_sender, self.outbounds, {
                 'from': '+1234',
                 'content': 'testcontent',
                 'event_url': 'http://test.org'
@@ -305,7 +305,7 @@ class TestChannel(JunebugTestBase):
         yield self.api.inbounds.store_vumi_message('channel-id', in_msg)
 
         msg = yield channel.send_reply_message(
-            'channel-id', self.message_sender, self.outbounds, self.inbounds, {
+            self.message_sender, self.outbounds, self.inbounds, {
                 'reply_to': in_msg['message_id'],
                 'content': 'testcontent',
             })
@@ -330,7 +330,7 @@ class TestChannel(JunebugTestBase):
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
         self.assertFailure(channel.send_reply_message(
-            'channel-id', self.message_sender, self.outbounds, self.inbounds, {
+            self.message_sender, self.outbounds, self.inbounds, {
                 'reply_to': 'i-do-not-exist',
                 'content': 'testcontent',
             }), MessageNotFound)
@@ -352,7 +352,7 @@ class TestChannel(JunebugTestBase):
         yield self.api.inbounds.store_vumi_message('channel-id', in_msg)
 
         msg = yield channel.send_reply_message(
-            'channel-id', self.message_sender, self.outbounds, self.inbounds, {
+            self.message_sender, self.outbounds, self.inbounds, {
                 'reply_to': in_msg['message_id'],
                 'content': 'testcontent',
                 'event_url': 'http://test.org',


### PR DESCRIPTION
The character limits specified on the channel config should be checked before a message is sent, and an http error should be returned if the character limit is exceeded.