### PR TITLE
Generic channel support

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -204,14 +204,24 @@ class Channel(object):
         }
 
     @property
+    def _available_transports(self):
+        if self.config.replace_channels:
+            return self.config.channels
+        else:
+            channels = {}
+            channels.update(transports)
+            channels.update(self.config.channels)
+            return channels
+
+    @property
     def _transport_cls_name(self):
-        cls_name = transports.get(self._properties.get('type'))
+        cls_name = self._available_transports.get(self._properties.get('type'))
 
         if cls_name is None:
             raise InvalidChannelType(
                 'Invalid channel type %r, must be one of: %s' % (
                     self._properties.get('type'),
-                    ', '.join(transports.keys())))
+                    ', '.join(self._available_transports.keys())))
 
         return cls_name
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -71,12 +71,13 @@ def parse_arguments(args):
         'messages (in seconds). Defaults to 172800 seconds (2 days)')
     parser.add_argument(
         '--channels', '-ch', dest='channels', type=str, action='append',
-        help='The mapping between the channel names and python classes. '
-        'Defaults to {}')
+        help='Add a mapping to the list of channels, in the format '
+        '"channel_type:python_class".')
     parser.add_argument(
         '--replace-channels', '-rch', dest='replace_channels', type=bool,
         help='If True, replaces the default channels with `channels`. '
-        'If False, adds `channels` to the list of default channels')
+        'If False, adds `channels` to the list of default channels. Defaults'
+        ' to False.')
 
     return config_from_args(vars(parser.parse_args(args)))
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -69,6 +69,14 @@ def parse_arguments(args):
         '--outbound-message-ttl', '-ottl', dest='outbound_message_ttl',
         type=int, help='The maximum time allowed for events to arrive for '
         'messages (in seconds). Defaults to 172800 seconds (2 days)')
+    parser.add_argument(
+        '--channels', '-ch', dest='channels', type=str, action='append',
+        help='The mapping between the channel names and python classes. '
+        'Defaults to {}')
+    parser.add_argument(
+        '--replace-channels', '-rch', dest='replace_channels', type=bool,
+        help='If True, replaces the default channels with `channels`. '
+        'If False, adds `channels` to the list of default channels')
 
     return config_from_args(vars(parser.parse_args(args)))
 
@@ -115,6 +123,7 @@ def config_from_args(args):
     config = load_config(args.pop('config_filename', None))
     config['redis'] = parse_redis(config.get('redis', {}), args)
     config['amqp'] = parse_amqp(config.get('amqp', {}), args)
+    parse_channels(args)
     return JunebugConfig(conjoin(config, args))
 
 
@@ -143,6 +152,16 @@ def parse_amqp(config, args):
     })
 
     return config
+
+
+def parse_channels(args):
+    channels = {}
+    for ch in args.get('channels', {}):
+        key, value = ch.split(':')
+        channels[key] = value
+
+    if len(channels) > 0:
+        args['channels'] = channels
 
 
 def omit_nones(d):

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -49,5 +49,5 @@ class JunebugConfig(Config):
 
     replace_channels = ConfigBool(
         "If `True`, replaces the default channels with `channels`. If `False`,"
-        " `channels` is added to the default channels.",
+        " `channels` is added to the default channels. Defaults to False.",
         default=False)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -1,5 +1,5 @@
 from confmodel import Config
-from confmodel.fields import ConfigText, ConfigInt, ConfigDict
+from confmodel.fields import ConfigBool, ConfigText, ConfigInt, ConfigDict
 
 
 class JunebugConfig(Config):
@@ -42,3 +42,12 @@ class JunebugConfig(Config):
     outbound_message_ttl = ConfigInt(
         "Maximum time (in seconds) allowed for events to arrive for messages",
         default=60 * 60 * 24 * 2)
+
+    channels = ConfigDict(
+        "Mapping between channel types and python classes.",
+        default={})
+
+    replace_channels = ConfigBool(
+        "If `True`, replaces the default channels with `channels`. If `False`,"
+        " `channels` is added to the default channels.",
+        default=False)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -49,5 +49,5 @@ class JunebugConfig(Config):
 
     replace_channels = ConfigBool(
         "If `True`, replaces the default channels with `channels`. If `False`,"
-        " `channels` is added to the default channels. Defaults to False.",
+        " `channels` is added to the default channels.",
         default=False)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -88,11 +88,12 @@ class JunebugTestBase(TestCase):
     @inlineCallbacks
     def create_channel(
             self, service, redis, transport_class,
-            properties=default_channel_properties, id=None):
+            properties=default_channel_properties, id=None, config=None):
         '''Creates and starts, and saves a channel, with a
         TelnetServerTransport transport'''
         properties = deepcopy(properties)
-        config = yield self.create_channel_config()
+        if config is None:
+            config = yield self.create_channel_config()
         channel = Channel(
             redis, config, properties, id=id)
         properties['config']['transport_name'] = channel.id

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -63,6 +63,34 @@ class TestChannel(JunebugTestBase):
             channel.transport_worker)
 
     @inlineCallbacks
+    def test_transport_class_name_default(self):
+        config = yield self.create_channel_config(channels={})
+        properties = self.create_channel_properties(type='telnet')
+        channel = Channel(self.redis, config, properties)
+        self.assertEqual(
+            channel._transport_cls_name,
+            'vumi.transports.telnet.TelnetServerTransport')
+
+    @inlineCallbacks
+    def test_transport_class_name_specified(self):
+        config = yield self.create_channel_config(channels={'foo': 'bar.baz'})
+        properties = self.create_channel_properties(type='foo')
+        channel = Channel(self.redis, config, properties)
+        self.assertEqual(
+            channel._transport_cls_name,
+            'bar.baz')
+
+    @inlineCallbacks
+    def test_transport_class_name_overridden(self):
+        config = yield self.create_channel_config(
+            channels={'foo': 'bar.baz'}, replace_channels=True)
+        properties = self.create_channel_properties(type='telnet')
+        channel = Channel(self.redis, config, properties)
+        err = self.assertRaises(
+            InvalidChannelType, getattr, channel, '_transport_cls_name')
+        self.assertTrue(all(cls in err.message for cls in ['telnet', 'foo']))
+
+    @inlineCallbacks
     def test_start_channel_application(self):
         properties = self.create_channel_properties(mo_url='http://foo.org')
 

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -197,6 +197,37 @@ class TestCommandLine(JunebugTestBase):
         config = parse_arguments(['-ottl', '90'])
         self.assertEqual(config.outbound_message_ttl, 90)
 
+    def test_parse_arguments_channels(self):
+        '''Each channel mapping be specified by "--channels" or "-ch"'''
+        config = parse_arguments([])
+        self.assertEqual(config.channels, {})
+
+        config = parse_arguments(['--channels', 'foo:bar'])
+        self.assertEqual(config.channels, {'foo': 'bar'})
+
+        config = parse_arguments([
+            '--channels', 'foo:bar', '--channels', 'bar:foo'])
+        self.assertEqual(config.channels, {'foo': 'bar', 'bar': 'foo'})
+
+        config = parse_arguments(['-ch', 'foo:bar'])
+        self.assertEqual(config.channels, {'foo': 'bar'})
+
+        config = parse_arguments(['-ch', 'foo:bar', '-ch', 'bar:foo'])
+        self.assertEqual(config.channels, {'foo': 'bar', 'bar': 'foo'})
+
+    def test_parse_arguments_replace_channels(self):
+        '''The replace channels command line argument can be specified by
+        "--replace-channels" or "-rch" and has a default value of False
+        '''
+        config = parse_arguments([])
+        self.assertEqual(config.replace_channels, False)
+
+        config = parse_arguments(['--replace-channels', 'true'])
+        self.assertEqual(config.replace_channels, True)
+
+        config = parse_arguments(['-rch', 'true'])
+        self.assertEqual(config.replace_channels, True)
+
     def test_config_file(self):
         '''The config file command line argument can be specified by
         "--config" or "-c"'''
@@ -220,6 +251,7 @@ class TestCommandLine(JunebugTestBase):
                 },
                 'inbound_message_ttl': 80,
                 'outbound_message_ttl': 90,
+                'channels': {'foo': 'bar'},
             }
         })
 
@@ -238,6 +270,7 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.amqp['password'], 'nimda')
         self.assertEqual(config.inbound_message_ttl, 80)
         self.assertEqual(config.outbound_message_ttl, 90)
+        self.assertEqual(config.channels, {'foo': 'bar'})
 
         config = parse_arguments(['-c', '/foo/bar.yaml'])
         self.assertEqual(config.interface, 'lolcathost')
@@ -254,6 +287,7 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.amqp['password'], 'nimda')
         self.assertEqual(config.inbound_message_ttl, 80)
         self.assertEqual(config.outbound_message_ttl, 90)
+        self.assertEqual(config.channels, {'foo': 'bar'})
 
     def test_config_file_overriding(self):
         '''Config file options are overriden by their corresponding command


### PR DESCRIPTION
The plan is to have a default list of mappings between friendly channel types, and python classes. This list can either be appended to, or replaced, via config.