### PR TITLE
Support GET health events

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -9,7 +9,7 @@ from vumi.service import WorkerCreator
 from vumi.servicemaker import VumiOptions
 
 from junebug.stores import StatusStore
-from junebug.utils import api_from_message, message_from_api
+from junebug.utils import api_from_message, message_from_api, api_from_status
 from junebug.error import JunebugError
 
 
@@ -154,7 +154,10 @@ class Channel(object):
 
     @inlineCallbacks
     def _get_status(self):
-        components = yield self.sstore.get_statuses_dict(self.id)
+        components = yield self.sstore.get_statuses(self.id)
+        components = dict(
+            (k, api_from_status(self.id, v)) for k, v in components.iteritems()
+        )
 
         status_values = {
             'down': 0,

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -8,6 +8,7 @@ from vumi.message import TransportUserMessage
 from vumi.service import WorkerCreator
 from vumi.servicemaker import VumiOptions
 
+from junebug.stores import StatusStore
 from junebug.utils import api_from_message, message_from_api
 from junebug.error import JunebugError
 
@@ -80,6 +81,8 @@ class Channel(object):
         self.application_worker = None
         self.status_application_worker = None
 
+        self.sstore = StatusStore(self.redis)
+
     @property
     def application_id(self):
         return self.APPLICATION_ID % (self.id,)
@@ -141,13 +144,36 @@ class Channel(object):
         yield channel_redis.delete('properties')
         yield self.redis.srem('channels', self.id)
 
+    @inlineCallbacks
     def status(self):
         '''Returns a dict with the configuration and status of the channel'''
         status = deepcopy(self._properties)
         status['id'] = self.id
-        # TODO: Implement channel status
-        status['status'] = {}
-        return status
+        status['status'] = yield self._get_status()
+        returnValue(status)
+
+    @inlineCallbacks
+    def _get_status(self):
+        components = yield self.sstore.get_statuses_dict(self.id)
+
+        status_values = {
+            'down': 0,
+            'degraded': 1,
+            'ok': 2,
+        }
+
+        try:
+            status = min(
+                (c['status'] for c in components.values()),
+                key=status_values.get)
+        except ValueError:
+            # No statuses
+            returnValue({})
+
+        returnValue({
+            'components': components,
+            'status': status
+        })
 
     @classmethod
     @inlineCallbacks

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -139,4 +139,7 @@ class StatusStore(BaseStore):
         dictionary'''
         key = self.get_key(channel_id)
         statuses = yield self.load_all(key)
-        returnValue({k: json.loads(v) for k, v in statuses.iteritems()})
+        res = {}
+        for k, v in statuses.iteritems():
+            res[k] = json.loads(v)
+        returnValue(res)

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -1,3 +1,4 @@
+import json
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 from vumi.message import TransportEvent, TransportUserMessage
@@ -131,3 +132,11 @@ class StatusStore(BaseStore):
         component.'''
         key = self.get_key(channel_id)
         return self.store_property(key, status['component'], status.to_json())
+
+    @inlineCallbacks
+    def get_statuses_dict(self, channel_id):
+        '''Returns the latest status message for each component in a
+        dictionary'''
+        key = self.get_key(channel_id)
+        statuses = yield self.load_all(key)
+        returnValue({k: json.loads(v) for k, v in statuses.iteritems()})

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -1,7 +1,6 @@
-import json
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from vumi.message import TransportEvent, TransportUserMessage
+from vumi.message import TransportEvent, TransportUserMessage, TransportStatus
 
 
 class BaseStore(object):
@@ -134,12 +133,12 @@ class StatusStore(BaseStore):
         return self.store_property(key, status['component'], status.to_json())
 
     @inlineCallbacks
-    def get_statuses_dict(self, channel_id):
+    def get_statuses(self, channel_id):
         '''Returns the latest status message for each component in a
         dictionary'''
         key = self.get_key(channel_id)
         statuses = yield self.load_all(key)
-        res = {}
-        for k, v in statuses.iteritems():
-            res[k] = json.loads(v)
-        returnValue(res)
+        returnValue(dict(
+            (k, TransportStatus.from_json(v))
+            for k, v in statuses.iteritems()
+        ))

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -3,7 +3,7 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.message import TransportUserMessage, TransportStatus
 from vumi.transports.telnet import TelnetServerTransport
 
-from junebug.utils import api_from_message, conjoin
+from junebug.utils import api_from_message, api_from_status, conjoin
 from junebug.workers import ChannelStatusWorker, MessageForwardingWorker
 from junebug.channel import (
     Channel, ChannelNotFound, InvalidChannelType, MessageNotFound)
@@ -283,13 +283,17 @@ class TestChannel(JunebugTestBase):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
-        status = TransportStatus(status='ok', component='foo')
+        status = TransportStatus(
+            status='ok',
+            component='foo',
+            type='bar',
+            message='Bar')
         yield channel.sstore.store_status('channel-id', status)
 
         self.assertEqual((yield channel.status())['status'], {
             'status': 'ok',
             'components': {
-                'foo': json.loads(status.to_json()),
+                'foo': api_from_status('channel-id', status),
             }
         })
 
@@ -301,9 +305,13 @@ class TestChannel(JunebugTestBase):
         components = {}
 
         for i in range(5):
-            status = TransportStatus(status='ok', component=i)
+            status = TransportStatus(
+                status='ok',
+                component=i,
+                type='bar',
+                message='Bar')
             yield channel.sstore.store_status('channel-id', status)
-            components[str(i)] = json.loads(status.to_json())
+            components[str(i)] = api_from_status('channel-id', status)
 
         self.assertEqual((yield channel.status())['status'], {
             'status': 'ok',
@@ -318,13 +326,21 @@ class TestChannel(JunebugTestBase):
         components = {}
 
         for i in range(5):
-            status = TransportStatus(status='ok', component=i)
+            status = TransportStatus(
+                status='ok',
+                component=i,
+                type='bar',
+                message='Bar')
             yield channel.sstore.store_status('channel-id', status)
-            components[str(i)] = json.loads(status.to_json())
+            components[str(i)] = api_from_status('channel-id', status)
 
-        status = TransportStatus(status='degraded', component=5)
+        status = TransportStatus(
+            status='degraded',
+            component=5,
+            type='bar',
+            message='Bar')
         yield channel.sstore.store_status('channel-id', status)
-        components['5'] = json.loads(status.to_json())
+        components['5'] = api_from_status('channel-id', status)
 
         self.assertEqual((yield channel.status())['status'], {
             'status': 'degraded',
@@ -339,17 +355,29 @@ class TestChannel(JunebugTestBase):
         components = {}
 
         for i in range(5):
-            status = TransportStatus(status='ok', component=i)
+            status = TransportStatus(
+                status='ok',
+                component=i,
+                type='bar',
+                message='Bar')
             yield channel.sstore.store_status('channel-id', status)
-            components[str(i)] = json.loads(status.to_json())
+            components[str(i)] = api_from_status('channel-id', status)
 
-        status = TransportStatus(status='degraded', component=5)
+        status = TransportStatus(
+            status='degraded',
+            component=5,
+            type='bar',
+            message='Bar')
         yield channel.sstore.store_status('channel-id', status)
-        components['5'] = json.loads(status.to_json())
+        components['5'] = api_from_status('channel-id', status)
 
-        status = TransportStatus(status='down', component=6)
+        status = TransportStatus(
+            status='down',
+            component=6,
+            type='bar',
+            message='Bar')
         yield channel.sstore.store_status('channel-id', status)
-        components['6'] = json.loads(status.to_json())
+        components['6'] = api_from_status('channel-id', status)
 
         self.assertEqual((yield channel.status())['status'], {
             'status': 'down',

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -1,4 +1,3 @@
-import json
 from twisted.internet.defer import inlineCallbacks, returnValue
 from vumi.message import TransportEvent, TransportUserMessage, TransportStatus
 
@@ -296,10 +295,10 @@ class TestStatusStore(JunebugTestBase):
         status = TransportStatus(status='ok', component='foo')
         yield store.store_status('channelid', status)
 
-        stored_statuses = yield store.get_statuses_dict('channelid')
+        stored_statuses = yield store.get_statuses('channelid')
 
         self.assertEqual(
-            stored_statuses, {'foo': json.loads(status.to_json())})
+            stored_statuses, {'foo': status})
 
     @inlineCallbacks
     def test_load_many_statuses(self):
@@ -308,8 +307,8 @@ class TestStatusStore(JunebugTestBase):
         for i in range(5):
             status = TransportStatus(status='ok', component=i)
             yield store.store_status('channelid', status)
-            expected[str(i)] = json.loads(status.to_json())
+            expected[str(i)] = status
 
-        stored_statuses = yield store.get_statuses_dict('channelid')
+        stored_statuses = yield store.get_statuses('channelid')
 
         self.assertEqual(stored_statuses, expected)


### PR DESCRIPTION
A GET request to `/channels/<channel-id>` should have the latest health event from each component in it.