### PR TITLE
POST received events to status_url in channel status worker

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -220,6 +220,7 @@ class Channel(object):
             'status_connector_name': self.STATUS_QUEUE % self.id,
             'redis_manager': self.config.redis,
             'channel_id': self.id,
+            'status_url': self._properties.get('status_url'),
         }
 
     @property

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -203,9 +203,9 @@ class JunebugTestBase(TestCase):
             'vumi', queue)
 
     def assert_was_logged(self, msg):
-        return any(
+        return self.assertTrue(any(
             msg in log.getMessage()
-            for log in self.logging_handler.buffer)
+            for log in self.logging_handler.buffer))
 
     def assert_request(self, req, method=None, body=None, headers=None):
         if method is not None:

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -1,11 +1,16 @@
+import json
 from copy import deepcopy
 import logging
 import logging.handlers
+
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.trial.unittest import TestCase
 from twisted.web.server import Site
+
+from klein import Klein
 from txamqp.client import TwistedDelegate
+
 from vumi.utils import vumi_resource_path
 from vumi.service import get_spec
 from vumi.tests.fake_amqp import FakeAMQPBroker, FakeAMQPChannel
@@ -37,6 +42,41 @@ class FakeAmqpClient(JunebugAMQClient):
         finally:
             self.channelLock.release()
         returnValue(ch)
+
+
+class RequestLoggingApi(object):
+    app = Klein()
+
+    def __init__(self):
+        self.requests = []
+        self.url = None
+
+    def setup(self):
+        self.port = reactor.listenTCP(
+            0, Site(self.app.resource()), interface='127.0.0.1')
+
+        addr = self.port.getHost()
+        self.url = "http://%s:%s" % (addr.host, addr.port)
+
+    def teardown(self):
+        self.port.stopListening()
+
+    @app.route('/')
+    def log_request(self, request):
+        self.requests.append({
+            'request': request,
+            'body': request.content.read(),
+            })
+        return ''
+
+    @app.route('/bad/')
+    def bad_request(self, request):
+        self.requests.append({
+            'request': request,
+            'body': request.content.read(),
+            })
+        request.setResponseCode(500)
+        return 'test-error-response'
 
 
 class JunebugTestBase(TestCase):
@@ -161,3 +201,28 @@ class JunebugTestBase(TestCase):
         amqp_client = self.api.message_sender.client
         return amqp_client.broker.get_messages(
             'vumi', queue)
+
+    def assert_was_logged(self, msg):
+        return any(
+            msg in log.getMessage()
+            for log in self.logging_handler.buffer)
+
+    def assert_request(self, req, method=None, body=None, headers=None):
+        if method is not None:
+            self.assertEqual(req['request'].method, 'POST')
+
+        if headers is not None:
+            for name, values in headers.iteritems():
+                self.assertEqual(
+                    req['request'].requestHeaders.getRawHeaders(name),
+                    values)
+
+        if body is not None:
+            self.assertEqual(json.loads(req['body']), body)
+
+    def assert_body_contains(self, req, **fields):
+        body = json.loads(req['body'])
+
+        self.assertEqual(
+            dict((k, v) for k, v in body.iteritems()),
+            body)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -224,5 +224,5 @@ class JunebugTestBase(TestCase):
         body = json.loads(req['body'])
 
         self.assertEqual(
-            dict((k, v) for k, v in body.iteritems()),
-            body)
+            dict((k, v) for k, v in body.iteritems() if k in fields),
+            fields)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -203,7 +203,7 @@ class JunebugTestBase(TestCase):
             'vumi', queue)
 
     def assert_was_logged(self, msg):
-        return self.assertTrue(any(
+        self.assertTrue(any(
             msg in log.getMessage()
             for log in self.logging_handler.buffer))
 

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -126,7 +126,18 @@ class TestChannel(JunebugTestBase):
             'redis_manager': channel.config.redis,
             'status_connector_name': '%s.status' % channel.id,
             'channel_id': channel.id,
+            'status_url': None,
         })
+
+    @inlineCallbacks
+    def test_start_channel_status_application_status_url(self):
+        properties = self.create_channel_properties(status_url='example.org')
+
+        channel = yield self.create_channel(
+            self.service, self.redis, TelnetServerTransport, properties)
+
+        worker = channel.status_application_worker
+        self.assertEqual(worker.config['status_url'], 'example.org')
 
     @inlineCallbacks
     def test_channel_character_limit(self):

--- a/junebug/tests/test_utils.py
+++ b/junebug/tests/test_utils.py
@@ -11,9 +11,9 @@ from klein import Klein
 from junebug.tests.utils import ToyServer
 from junebug.utils import (
     response, json_body, conjoin, omit,
-    message_from_api, api_from_message, api_from_event)
+    message_from_api, api_from_message, api_from_event, api_from_status)
 
-from vumi.message import TransportUserMessage, TransportEvent
+from vumi.message import TransportUserMessage, TransportEvent, TransportStatus
 
 
 class TestUtils(TestCase):
@@ -280,4 +280,21 @@ class TestUtils(TestCase):
             'message_id': 'msg-21',
             'timestamp': date(2321, 2, 3),
             'event_details': {},
+        })
+
+    def test_api_from_status(self):
+        status = TransportStatus(
+            component='foo',
+            status='ok',
+            type='bar',
+            message='Bar',
+            details={'baz': 'quux'})
+
+        self.assertEqual(api_from_status('channel-23', status), {
+            'channel_id': 'channel-23',
+            'status': 'ok',
+            'component': 'foo',
+            'type': 'bar',
+            'message': 'Bar',
+            'details': {'baz': 'quux'}
         })

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -1,12 +1,8 @@
-import json
-
 import treq
-from klein import Klein
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web.client import HTTPConnectionPool
-from twisted.web.server import Site
 
 from vumi.application.tests.helpers import ApplicationHelper
 from vumi.message import TransportUserMessage, TransportEvent, TransportStatus
@@ -14,43 +10,16 @@ from vumi.tests.helpers import PersistenceHelper
 
 from junebug.utils import conjoin, api_from_event
 from junebug.workers import ChannelStatusWorker, MessageForwardingWorker
-from junebug.tests.helpers import JunebugTestBase
-
-
-class RequestLoggingApi(object):
-    app = Klein()
-
-    def __init__(self):
-        self.requests = []
-
-    @app.route('/')
-    def log_request(self, request):
-        self.requests.append({
-            'request': request,
-            'body': request.content.read(),
-            })
-        return ''
-
-    @app.route('/bad/')
-    def bad_request(self, request):
-        self.requests.append({
-            'request': request,
-            'body': request.content.read(),
-            })
-        request.setResponseCode(500)
-        return 'test-error-response'
+from junebug.tests.helpers import JunebugTestBase, RequestLoggingApi
 
 
 class TestMessageForwardingWorker(JunebugTestBase):
     @inlineCallbacks
     def setUp(self):
         self.logging_api = RequestLoggingApi()
-        port = reactor.listenTCP(
-            0, Site(self.logging_api.app.resource()),
-            interface='127.0.0.1')
-        self.addCleanup(port.stopListening)
-        addr = port.getHost()
-        self.url = "http://%s:%s" % (addr.host, addr.port)
+        self.logging_api.setup()
+        self.addCleanup(self.logging_api.teardown)
+        self.url = self.logging_api.url
 
         self.worker = yield self.get_worker()
         connection_pool = HTTPConnectionPool(reactor, persistent=False)
@@ -79,31 +48,6 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         worker = yield app_helper.get_application(config)
         returnValue(worker)
-
-    def assert_was_logged(self, msg):
-        return any(
-            msg in log.getMessage()
-            for log in self.logging_handler.buffer)
-
-    def assert_request(self, req, method=None, body=None, headers=None):
-        if method is not None:
-            self.assertEqual(req['request'].method, 'POST')
-
-        if headers is not None:
-            for name, values in headers.iteritems():
-                self.assertEqual(
-                    req['request'].requestHeaders.getRawHeaders(name),
-                    values)
-
-        if body is not None:
-            self.assertEqual(json.loads(req['body']), body)
-
-    def assert_body_contains(self, req, **fields):
-        body = json.loads(req['body'])
-
-        self.assertEqual(
-            dict((k, v) for k, v in body.iteritems()),
-            body)
 
     @inlineCallbacks
     def assert_event_stored(self, event):

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -191,7 +191,7 @@ class TestMessageForwardingWorker(JunebugTestBase):
             timestamp='2015-09-22 15:39:44.827794')
 
         yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', self.url)
+            self.worker.channel_id, 'msg-21', "%s/bad/" % (self.url,))
 
         yield self.worker.consume_nack(event)
 

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -385,7 +385,6 @@ class TestChannelStatusWorker(JunebugTestBase):
 
         yield worker.consume_status(status)
 
-        self.assert_was_logged("'content': 'testcontent'")
-        self.assert_was_logged("'to': '+1234'")
         self.assert_was_logged('500')
         self.assert_was_logged('test-error-response')
+        self.assert_was_logged(repr(status))

--- a/junebug/utils.py
+++ b/junebug/utils.py
@@ -94,6 +94,17 @@ def api_from_event(channel_id, event):
     }, parser(channel_id, event))
 
 
+def api_from_status(channel_id, status):
+    return {
+        'channel_id': channel_id,
+        'component': status['component'],
+        'status': status['status'],
+        'type': status['type'],
+        'message': status['message'],
+        'details': status['details'],
+    }
+
+
 def _api_from_event_ack(channel_id, event):
     return {
         'event_type': 'submitted',

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -137,7 +137,7 @@ class ChannelStatusConfig(BaseConfig):
 
     status_url = ConfigText(
         "Optional url to POST status events to",
-        static=True)
+        default=None, static=True)
 
 
 class ChannelStatusWorker(BaseWorker):
@@ -165,7 +165,7 @@ class ChannelStatusWorker(BaseWorker):
         '''Store the status in redis under the correct component'''
         yield self.store.store_status(self.config['channel_id'], status)
 
-        if 'status_url' in self.config:
+        if self.config.get('status_url') is not None:
             yield self.send_status(status)
 
     @inlineCallbacks

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -11,7 +11,7 @@ from vumi.message import JSONMessageEncoder
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.worker import BaseConfig, BaseWorker
 
-from junebug.utils import api_from_message, api_from_event
+from junebug.utils import api_from_message, api_from_event, api_from_status
 from junebug.stores import (
     InboundMessageStore, OutboundMessageStore, StatusStore)
 
@@ -121,17 +121,6 @@ class MessageForwardingWorker(ApplicationWorker):
         return self.outbounds.load_event_url(self.channel_id, msg_id)
 
 
-def request_failed(resp):
-    return resp.code < 200 or resp.code >= 300
-
-
-def post(url, data):
-    return treq.post(
-        url.encode('utf-8'),
-        data=json.dumps(data, cls=JSONMessageEncoder),
-        headers={'Content-Type': 'application/json'})
-
-
 class ChannelStatusConfig(BaseConfig):
     '''Config for the ChannelStatusWorker'''
     status_connector_name = ConfigText(
@@ -145,6 +134,10 @@ class ChannelStatusConfig(BaseConfig):
     channel_id = ConfigText(
         "The channel id which this worker is consuming statuses for",
         required=True, static=True)
+
+    status_url = ConfigText(
+        "Optional url to POST status events to",
+        static=True)
 
 
 class ChannelStatusWorker(BaseWorker):
@@ -167,6 +160,32 @@ class ChannelStatusWorker(BaseWorker):
     def teardown_worker(self):
         pass
 
+    @inlineCallbacks
     def consume_status(self, status):
         '''Store the status in redis under the correct component'''
-        return self.store.store_status(self.config['channel_id'], status)
+        yield self.store.store_status(self.config['channel_id'], status)
+
+        if 'status_url' in self.config:
+            yield self.send_status(status)
+
+    @inlineCallbacks
+    def send_status(self, status):
+        data = api_from_status(self.config['channel_id'], status)
+        resp = yield post(self.config['status_url'], data)
+
+        if request_failed(resp):
+            logging.exception(
+                'Error sending status event, received HTTP code %r with '
+                'body %r. Status event: %r'
+                % (resp.code, (yield resp.content()), status))
+
+
+def request_failed(resp):
+    return resp.code < 200 or resp.code >= 300
+
+
+def post(url, data):
+    return treq.post(
+        url.encode('utf-8'),
+        data=json.dumps(data, cls=JSONMessageEncoder),
+        headers={'Content-Type': 'application/json'})


### PR DESCRIPTION
#44 adds a worker that consumes status events published by a transport. The plan is to change the worker to post received events to a `status_url` given to it via its config.