### PR TITLE
Persistent state

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -1,4 +1,3 @@
-import json
 from klein import Klein
 import logging
 from werkzeug.exceptions import HTTPException
@@ -52,16 +51,7 @@ class JunebugApi(object):
         self.outbounds = OutboundMessageStore(
             self.redis, self.config.outbound_message_ttl)
 
-        yield self._start_stored_channels()
-
-    @inlineCallbacks
-    def _start_stored_channels(self):
-        ids = yield Channel.get_all(self.redis)
-        for id in ids:
-            properties = yield self.redis.get('%s:properties' % id)
-            properties = json.loads(properties)
-            channel = Channel(self.redis, self.config, properties, id)
-            yield channel.start(self.service)
+        yield Channel.start_all_channels(self.redis, self.config, self.service)
 
     @inlineCallbacks
     def teardown(self):

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -206,9 +206,7 @@ class Channel(object):
     def start_all_channels(cls, redis, config, parent):
         '''Ensures that all of the stored channels are running'''
         for id in (yield cls.get_all(redis)):
-            try:
-                yield cls.from_id(redis, config, id, parent)
-            except KeyError:
+            if id not in parent.namedServices:
                 properties = json.loads((
                     yield redis.get('%s:properties' % id)))
                 channel = cls(redis, config, properties, id)

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -201,6 +201,19 @@ class Channel(object):
         channels = yield redis.smembers('channels')
         returnValue(channels)
 
+    @classmethod
+    @inlineCallbacks
+    def start_all_channels(cls, redis, config, parent):
+        '''Ensures that all of the stored channels are running'''
+        for id in (yield cls.get_all(redis)):
+            try:
+                yield cls.from_id(redis, config, id, parent)
+            except KeyError:
+                properties = json.loads((
+                    yield redis.get('%s:properties' % id)))
+                channel = cls(redis, config, properties, id)
+                yield channel.start(parent)
+
     @inlineCallbacks
     def send_message(self, sender, outbounds, msg):
         '''Sends a message.'''

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -164,6 +164,9 @@ class JunebugTestBase(TestCase):
     def start_server(self):
         '''Starts a junebug server. Stores the service to "self.service", and
         the url at "self.url"'''
+        # TODO: This setup is very manual, because we don't call
+        # service.startService. This must be fixed to close mirror the real
+        # program with our tests.
         config = yield self.create_channel_config()
         self.service = JunebugService(config)
         self.api = JunebugApi(

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -189,6 +189,9 @@ class JunebugTestBase(TestCase):
 
     @inlineCallbacks
     def stop_server(self):
+        # TODO: This teardown is very messy, because we don't actually call
+        # service.startService. This needs to be fixed in order to ensure that
+        # our tests are mirroring the real program closely.
         yield self.service.stopService()
         for service in self.service:
             service.disownServiceParent()

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -190,12 +190,10 @@ class JunebugTestBase(TestCase):
     @inlineCallbacks
     def stop_server(self):
         yield self.service.stopService()
-        for service in self.service.services:
-            yield service.stopService()
-        self.service.services = []
+        for service in self.service:
+            yield self.service.removeService(service)
         for service in self.service.namedServices.values():
-            yield service.stopService()
-        self.service.namedServices = {}
+            yield self.service.removeService(service)
 
     def get_message_sender(self):
         '''Creates a new MessageSender object, with a fake amqp client'''

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -191,9 +191,9 @@ class JunebugTestBase(TestCase):
     def stop_server(self):
         yield self.service.stopService()
         for service in self.service:
-            yield self.service.removeService(service)
+            service.disownServiceParent()
         for service in self.service.namedServices.values():
-            yield self.service.removeService(service)
+            service.disownServiceParent()
 
     def get_message_sender(self):
         '''Creates a new MessageSender object, with a fake amqp client'''

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -59,6 +59,35 @@ class TestJunebugApi(JunebugTestBase):
                 })
 
     @inlineCallbacks
+    def test_startup_single_channel(self):
+        properties = self.create_channel_properties()
+        resp = yield self.post('/channels/', properties)
+        id = (yield resp.json())['result']['id']
+
+        yield self.stop_server()
+        self.assertFalse(id in self.service.namedServices)
+
+        yield self.start_server()
+        self.assertTrue(id in self.service.namedServices)
+
+    @inlineCallbacks
+    def test_startup_multiple_channel(self):
+        ids = []
+        for i in range(5):
+            properties = self.create_channel_properties()
+            resp = yield self.post('/channels/', properties)
+            id = (yield resp.json())['result']['id']
+            ids.append(id)
+
+        yield self.stop_server()
+        for id in ids:
+            self.assertFalse(id in self.service.namedServices)
+
+        yield self.start_server()
+        for id in ids:
+            self.assertTrue(id in self.service.namedServices)
+
+    @inlineCallbacks
     def test_get_channel_list(self):
         redis = yield self.get_redis()
         properties = self.create_channel_properties()

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -416,11 +416,7 @@ class TestChannel(JunebugTestBase):
         channel2 = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
         self.assertTrue(channel2.id in self.service.namedServices)
-        channel1 = yield Channel.from_id(
-            self.redis, self.config, channel1.id, self.service)
-        yield channel1.stop()
         yield channel2.stop()
-        self.assertFalse(channel1.id in self.service.namedServices)
         self.assertFalse(channel2.id in self.service.namedServices)
         yield Channel.start_all_channels(
             self.redis, self.config, self.service)


### PR DESCRIPTION
We do store a list of all the channels in redis, but when junebug starts we don't start any of them. We should start all of the channels stored in redis when junebug starts up, so that they don't need to all be recreated every time the process restarts.