### PR TITLE
Add infrastructure to use plugins

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -4,6 +4,7 @@ from werkzeug.exceptions import HTTPException
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web import http
 from vumi.persist.txredis_manager import TxRedisManager
+from vumi.utils import load_class_by_string
 
 from junebug.amqp import MessageSender
 from junebug.channel import Channel
@@ -51,7 +52,15 @@ class JunebugApi(object):
         self.outbounds = OutboundMessageStore(
             self.redis, self.config.outbound_message_ttl)
 
-        yield Channel.start_all_channels(self.redis, self.config, self.service)
+        self.plugins = []
+        for plugin_config in self.config.plugins:
+            cls = load_class_by_string(plugin_config['type'])
+            plugin = cls()
+            yield plugin.start_plugin(plugin_config, self.config)
+            self.plugins.append(plugin)
+
+        yield Channel.start_all_channels(
+            self.redis, self.config, self.service, self.plugins)
 
     @inlineCallbacks
     def teardown(self):
@@ -123,7 +132,7 @@ class JunebugApi(object):
     def create_channel(self, request, body):
         '''Create a channel'''
         channel = Channel(
-            self.redis, self.config, body)
+            self.redis, self.config, body, self.plugins)
         yield channel.save()
         yield channel.start(self.service)
         returnValue(response(
@@ -134,7 +143,7 @@ class JunebugApi(object):
     def get_channel(self, request, channel_id):
         '''Return the channel configuration and a nested status object'''
         channel = yield Channel.from_id(
-            self.redis, self.config, channel_id, self.service)
+            self.redis, self.config, channel_id, self.service, self.plugins)
         resp = yield channel.status()
         returnValue(response(
             request, 'channel found', resp))
@@ -169,7 +178,7 @@ class JunebugApi(object):
     def modify_channel(self, request, body, channel_id):
         '''Mondify the channel configuration'''
         channel = yield Channel.from_id(
-            self.redis, self.config, channel_id, self.service)
+            self.redis, self.config, channel_id, self.service, self.plugins)
         resp = yield channel.update(body)
         returnValue(response(
             request, 'channel updated', resp))
@@ -179,7 +188,7 @@ class JunebugApi(object):
     def delete_channel(self, request, channel_id):
         '''Delete the channel'''
         channel = yield Channel.from_id(
-            self.redis, self.config, channel_id, self.service)
+            self.redis, self.config, channel_id, self.service, self.plugins)
         yield channel.stop()
         yield channel.delete()
         returnValue(response(
@@ -218,7 +227,7 @@ class JunebugApi(object):
                 'Only one of "from" and "reply_to" may be specified')
 
         channel = yield Channel.from_id(
-            self.redis, self.config, channel_id, self.service)
+            self.redis, self.config, channel_id, self.service, self.plugins)
 
         if 'to' in body:
             msg = yield channel.send_message(

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -65,6 +65,8 @@ class JunebugApi(object):
     @inlineCallbacks
     def teardown(self):
         yield self.redis.close_manager()
+        for plugin in self.plugins:
+            yield plugin.stop_plugin()
 
     @app.handle_errors(JunebugError)
     def generic_junebug_error(self, request, failure):

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import argparse
+import json
 import logging
 import logging.handlers
 import sys
@@ -76,6 +77,11 @@ def create_parser():
         help='If True, replaces the default channels with `channels`. '
         'If False, adds `channels` to the list of default channels. Defaults'
         ' to False.')
+    parser.add_argument(
+        '--plugin', '-pl', dest='plugins', type=str, action='append',
+        help='Add a plugins to the list of plugins, as a json blob of the '
+        'plugin config. Must contain a `type` key, with the full python class '
+        'path of the plugin')
 
     return parser
 
@@ -129,6 +135,7 @@ def config_from_args(args):
     config['redis'] = parse_redis(config.get('redis', {}), args)
     config['amqp'] = parse_amqp(config.get('amqp', {}), args)
     parse_channels(args)
+    args['plugins'] = parse_plugins(config.get('plugins', []), args)
     return JunebugConfig(conjoin(config, args))
 
 
@@ -167,6 +174,13 @@ def parse_channels(args):
 
     if len(channels) > 0:
         args['channels'] = channels
+
+
+def parse_plugins(config, args):
+    for plugin in args.get('plugins', []):
+        plugin = json.loads(plugin)
+        config.append(plugin)
+    return config
 
 
 def omit_nones(d):

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -1,5 +1,6 @@
 from confmodel import Config
-from confmodel.fields import ConfigBool, ConfigText, ConfigInt, ConfigDict
+from confmodel.fields import (
+    ConfigBool, ConfigText, ConfigInt, ConfigDict, ConfigList)
 
 
 class JunebugConfig(Config):
@@ -51,3 +52,8 @@ class JunebugConfig(Config):
         "If `True`, replaces the default channels with `channels`. If `False`,"
         " `channels` is added to the default channels.",
         default=False)
+
+    plugins = ConfigList(
+        "A list of dictionaries describing all of the enabled plugins. Each "
+        "item should have a `type` key, with the full python class name of "
+        "the plugin.", default=[])

--- a/junebug/plugin.py
+++ b/junebug/plugin.py
@@ -13,6 +13,13 @@ class JunebugPlugin(object):
         '''
         pass
 
+    def stop_plugin(self):
+        '''
+        Can be overridden with any required shutdown code for the plugin.
+        Can return a deferred.
+        '''
+        pass
+
     def channel_started(self, channel):
         '''
         Called whenever a channel is started. Should be implemented by the

--- a/junebug/plugin.py
+++ b/junebug/plugin.py
@@ -1,13 +1,15 @@
 class JunebugPlugin(object):
     '''Base class for all Junebug plugins'''
 
-    def start_plugin(self, config):
+    def start_plugin(self, config, junebug_config):
         '''
         Can be overridden with any required startup code for the plugin.
         Can return a deferred.
 
-        :param config: The config that Junebug was started with.
-        :type config: :class:`JunebugConfig`
+        :param config: The config specific to the plugin.
+        :type config: dictionary
+        :param junebug_config: The config that Junebug was started with.
+        :type junebug_config: :class:`JunebugConfig`
         '''
         pass
 

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -248,9 +248,13 @@ class FakeJunebugPlugin(JunebugPlugin):
     def _add_call(self, func_name, *args):
         self.calls.append((func_name, args))
 
-    def start_plugin(self, config):
+    def start_plugin(self, config, junebug_config):
         self.calls = []
-        self._add_call('start_plugin', config)
+        self._add_call('start_plugin', config, junebug_config)
+        return succeed(None)
+
+    def stop_plugin(self):
+        self._add_call('stop_plugin')
         return succeed(None)
 
     def channel_started(self, channel):

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -163,13 +163,14 @@ class JunebugTestBase(TestCase):
         returnValue(self.redis)
 
     @inlineCallbacks
-    def start_server(self):
+    def start_server(self, config=None):
         '''Starts a junebug server. Stores the service to "self.service", and
         the url at "self.url"'''
         # TODO: This setup is very manual, because we don't call
         # service.startService. This must be fixed to close mirror the real
         # program with our tests.
-        config = yield self.create_channel_config()
+        if config is None:
+            config = yield self.create_channel_config()
         self.service = JunebugService(config)
         self.api = JunebugApi(
             self.service, config)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -129,14 +129,15 @@ class JunebugTestBase(TestCase):
     @inlineCallbacks
     def create_channel(
             self, service, redis, transport_class,
-            properties=default_channel_properties, id=None, config=None):
+            properties=default_channel_properties, id=None, config=None,
+            plugins=[]):
         '''Creates and starts, and saves a channel, with a
         TelnetServerTransport transport'''
         properties = deepcopy(properties)
         if config is None:
             config = yield self.create_channel_config()
         channel = Channel(
-            redis, config, properties, id=id)
+            redis, config, properties, id=id, plugins=plugins)
         properties['config']['transport_name'] = channel.id
         yield channel.start(self.service)
         yield channel.save()

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -96,14 +96,14 @@ class TestJunebugApi(JunebugTestBase):
         resp = yield self.get('/channels/')
         yield self.assert_response(resp, http.OK, 'channels listed', [])
 
-        yield Channel(redis, config, properties, u'test-channel-1').save()
+        yield Channel(redis, config, properties, id=u'test-channel-1').save()
 
         resp = yield self.get('/channels/')
         yield self.assert_response(resp, http.OK, 'channels listed', [
             u'test-channel-1',
         ])
 
-        yield Channel(redis, config, properties, u'test-channel-2').save()
+        yield Channel(redis, config, properties, id=u'test-channel-2').save()
 
         resp = yield self.get('/channels/')
         yield self.assert_response(resp, http.OK, 'channels listed', [
@@ -192,7 +192,7 @@ class TestJunebugApi(JunebugTestBase):
         properties = self.create_channel_properties()
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
-        channel = Channel(redis, config, properties, u'test-channel')
+        channel = Channel(redis, config, properties, id=u'test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.get('/channels/test-channel')
@@ -220,7 +220,7 @@ class TestJunebugApi(JunebugTestBase):
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
 
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
 
@@ -240,7 +240,7 @@ class TestJunebugApi(JunebugTestBase):
         properties = self.create_channel_properties()
         config = yield self.create_channel_config()
 
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
 
@@ -277,7 +277,7 @@ class TestJunebugApi(JunebugTestBase):
     def test_delete_channel(self):
         config = yield self.create_channel_config()
         properties = self.create_channel_properties()
-        channel = Channel(self.redis, config, properties, 'test-channel')
+        channel = Channel(self.redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
 
@@ -324,7 +324,7 @@ class TestJunebugApi(JunebugTestBase):
         properties = self.create_channel_properties()
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post('/channels/test-channel/messages/', {
@@ -354,7 +354,7 @@ class TestJunebugApi(JunebugTestBase):
         properties = self.create_channel_properties()
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post('/channels/test-channel/messages/', {
@@ -482,7 +482,7 @@ class TestJunebugApi(JunebugTestBase):
         properties = self.create_channel_properties(character_limit=100)
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post('/channels/test-channel/messages/', {
@@ -507,7 +507,7 @@ class TestJunebugApi(JunebugTestBase):
             character_limit=len(content))
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post('/channels/test-channel/messages/', {
@@ -529,7 +529,7 @@ class TestJunebugApi(JunebugTestBase):
         properties = self.create_channel_properties(character_limit=10)
         config = yield self.create_channel_config()
         redis = yield self.get_redis()
-        channel = Channel(redis, config, properties, 'test-channel')
+        channel = Channel(redis, config, properties, id='test-channel')
         yield channel.save()
         yield channel.start(self.service)
         resp = yield self.post('/channels/test-channel/messages/', {

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -159,7 +159,7 @@ class TestChannel(JunebugTestBase):
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
         channel._properties['type'] = 'foo'
-        err = self.assertRaises(InvalidChannelType, channel.start, None)
+        err = yield self.assertFailure(channel.start(None), InvalidChannelType)
         self.assertTrue(all(
             s in err.message for s in ('xmpp', 'telnet', 'foo')))
 

--- a/junebug/tests/test_plugin.py
+++ b/junebug/tests/test_plugin.py
@@ -11,18 +11,32 @@ class TestFakeJunebugPlugin(JunebugTestBase):
         '''Stores the name of the function call and arguments in calls'''
         plugin = FakeJunebugPlugin()
         config = yield self.create_channel_config()
-        yield plugin.start_plugin(config)
+        yield plugin.start_plugin({'test': 'plugin_config'}, config)
 
-        [(name, [config_arg])] = plugin.calls
+        [(name, [plugin_config, config_arg])] = plugin.calls
         self.assertEqual(name, 'start_plugin')
         self.assertEqual(config_arg, config)
+        self.assertEqual(plugin_config, {'test': 'plugin_config'})
+
+    @inlineCallbacks
+    def test_plugin_stop_plugin(self):
+        '''Stores the name of the function call and arguments in calls'''
+        plugin = FakeJunebugPlugin()
+        config = yield self.create_channel_config()
+        yield plugin.start_plugin({'test': 'plugin_config'}, config)
+        plugin.calls = []
+
+        yield plugin.stop_plugin()
+
+        [(name, [])] = plugin.calls
+        self.assertEqual(name, 'stop_plugin')
 
     @inlineCallbacks
     def test_plugin_channel_started(self):
         '''Stores the name of the function call and arguments in calls'''
         plugin = FakeJunebugPlugin()
         config = yield self.create_channel_config()
-        yield plugin.start_plugin(config)
+        yield plugin.start_plugin({'test': 'pluginconfig'}, config)
         plugin.calls = []
 
         redis = yield self.get_redis()
@@ -39,7 +53,7 @@ class TestFakeJunebugPlugin(JunebugTestBase):
         '''Stores the name of the function call and arguments in calls'''
         plugin = FakeJunebugPlugin()
         config = yield self.create_channel_config()
-        yield plugin.start_plugin(config)
+        yield plugin.start_plugin({'test': 'plugin_config'}, config)
         plugin.calls = []
 
         redis = yield self.get_redis()


### PR DESCRIPTION
In https://github.com/praekelt/junebug/pull/51 we added the interface for Junebug plugins. We now need to add infrastructure to configure which plugins get started when Junebug starts, and to have all those plugins be called in the correct places.