### PR TITLE
Add message rates to channel status

### DIFF
--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -76,6 +76,12 @@ Channels
    :param dict components:
       An object showing the most recent status event for each component.
 
+   :param float inbound_message_rate:
+      The inbound messages per second for the channel.
+
+   :param float outbound_message_rate:
+      The outbound messages per second for the channel.
+
    **Example response**:
 
    .. sourcecode:: json
@@ -117,7 +123,9 @@ Channels
                    reasons: [],
                    details: {}
                 }
-            }
+            },
+            inbound_message_rate: 1.75,
+            outbound_message_rate: 7.11
           }
         }
       }

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -257,6 +257,22 @@ class JunebugTestBase(TestCase):
             dict((k, v) for k, v in body.iteritems() if k in fields),
             fields)
 
+    def generate_status(
+            self, level=None, components={}, inbound_message_rate=0,
+            outbound_message_rate=0):
+        '''Generates a status that the http API would respond with, given the
+        same parameters'''
+        return {
+            'status': level,
+            'components': components,
+            'inbound_message_rate': inbound_message_rate,
+            'outbound_message_rate': outbound_message_rate,
+        }
+
+    def assert_status(self, status, **kwargs):
+        '''Assert that the current channel status is correct'''
+        self.assertEqual(status, self.generate_status(**kwargs))
+
 
 class FakeJunebugPlugin(JunebugPlugin):
     def _add_call(self, func_name, *args):

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -154,7 +154,7 @@ class TestJunebugApi(JunebugTestBase):
 
         yield self.assert_response(
             resp, http.OK, 'channel created',
-            conjoin(properties, {'status': {}}),
+            conjoin(properties, {'status': self.generate_status()}),
             ignore=['id'])
 
     @inlineCallbacks
@@ -235,7 +235,7 @@ class TestJunebugApi(JunebugTestBase):
 
         yield self.assert_response(
             resp, http.OK, 'channel found', conjoin(properties, {
-                'status': {},
+                'status': self.generate_status(),
                 'id': 'test-channel',
             }))
 
@@ -265,7 +265,7 @@ class TestJunebugApi(JunebugTestBase):
 
         yield self.assert_response(
             resp, http.OK, 'channel updated', conjoin(properties, {
-                'status': {},
+                'status': self.generate_status(),
                 'id': 'test-channel',
                 'metadata': {'foo': 'bar'},
             }))
@@ -285,7 +285,7 @@ class TestJunebugApi(JunebugTestBase):
 
         yield self.assert_response(
             resp, http.OK, 'channel updated', conjoin(properties, {
-                'status': {},
+                'status': self.generate_status(),
                 'id': 'test-channel',
             }))
 

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -204,7 +204,7 @@ class TestChannel(JunebugTestBase):
 
         self.assertEqual(update, conjoin(properties, {
             'foo': 'bar',
-            'status': {},
+            'status': self.generate_status(),
             'id': channel.id,
             'config': conjoin(properties['config'], {
                 'transport_name': channel.id
@@ -300,7 +300,7 @@ class TestChannel(JunebugTestBase):
             self.service, self.redis, TelnetServerTransport, id='channel-id')
 
         self.assertEqual((yield channel.status()), conjoin(properties, {
-            'status': {},
+            'status': self.generate_status(),
             'id': 'channel-id',
             'config': conjoin(properties['config'], {
                 'transport_name': channel.id
@@ -319,12 +319,9 @@ class TestChannel(JunebugTestBase):
             message='Bar')
         yield channel.sstore.store_status('channel-id', status)
 
-        self.assertEqual((yield channel.status())['status'], {
-            'status': 'ok',
-            'components': {
-                'foo': api_from_status('channel-id', status),
-            }
-        })
+        self.assert_status((yield channel.status())['status'], components={
+            'foo': api_from_status('channel-id', status),
+            }, level='ok')
 
     @inlineCallbacks
     def test_channel_multiple_statuses_ok(self):
@@ -342,10 +339,9 @@ class TestChannel(JunebugTestBase):
             yield channel.sstore.store_status('channel-id', status)
             components[str(i)] = api_from_status('channel-id', status)
 
-        self.assertEqual((yield channel.status())['status'], {
-            'status': 'ok',
-            'components': components
-        })
+        self.assert_status(
+            (yield channel.status())['status'], level='ok',
+            components=components)
 
     @inlineCallbacks
     def test_channel_multiple_statuses_degraded(self):
@@ -371,10 +367,9 @@ class TestChannel(JunebugTestBase):
         yield channel.sstore.store_status('channel-id', status)
         components['5'] = api_from_status('channel-id', status)
 
-        self.assertEqual((yield channel.status())['status'], {
-            'status': 'degraded',
-            'components': components
-        })
+        self.assert_status(
+            (yield channel.status())['status'], level='degraded',
+            components=components)
 
     @inlineCallbacks
     def test_channel_multiple_statuses_down(self):
@@ -408,10 +403,9 @@ class TestChannel(JunebugTestBase):
         yield channel.sstore.store_status('channel-id', status)
         components['6'] = api_from_status('channel-id', status)
 
-        self.assertEqual((yield channel.status())['status'], {
-            'status': 'down',
-            'components': components
-        })
+        self.assert_status(
+            (yield channel.status())['status'], level='down',
+            components=components)
 
     @inlineCallbacks
     def test_get_all(self):


### PR DESCRIPTION
When a GET request is sent to `/channels/<channel-id>`, the inbound and outbound message rates should be returned.