### PR TITLE
Add logging service

### DIFF
--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -1,0 +1,127 @@
+import json
+import logging
+import time
+
+from twisted.python import log
+from twisted.python.log import ILogObserver
+from twisted.python.logfile import LogFile
+from twisted.application.service import Service
+
+from zope.interface import implements
+
+DEFAULT_LOG_CONTEXT_SENTINEL = "_JUNEBUG_CONTEXT_"
+
+
+class JunebugLogObserver(object):
+    """Twisted log observer that logs to a rotated log file."""
+    implements(ILogObserver)
+
+    DEFAULT_ERROR_LEVEL = logging.ERROR
+    DEFAULT_LOG_LEVEL = logging.INFO
+    LOG_LEVEL_THRESHOLD = logging.INFO
+    LOG_ENTRY = '%[(timestamp)s] '
+
+    def __init__(self, logfile, worker_id, log_context_sentinel=None):
+        '''
+        Create a new JunebugLogObserver.
+
+        :param logfile: File to write logs to.
+        :type logfile: :class:`twisted.python.logfile.LogFile`
+        :param str worker_id: ID of the worker that the log is for.
+        '''
+        if log_context_sentinel is None:
+            log_context_sentinel = DEFAULT_LOG_CONTEXT_SENTINEL
+        self.worker_id = worker_id
+        self.log_context_sentinel = log_context_sentinel
+        self.log_context = {self.log_context_sentinel: True}
+        self.logfile = logfile
+
+    def level_for_event(self, event):
+        '''Get the associated log level for an event.'''
+        level = event.get('logLevel')
+        if level is not None:
+            return level
+        if event.get('isError'):
+            return self.DEFAULT_ERROR_LEVEL
+        return self.DEFAULT_LOG_LEVEL
+
+    def logger_for_event(self, event):
+        '''Get the name of the logger for an event.'''
+        system = event.get('system', '-')
+        parts = [self.worker_id]
+        if system != '-':
+            parts.extend(system.split(','))
+        logger = ".".join(parts)
+        return logger.lower()
+
+    def _log_to_file(self, event):
+        '''Logs the specified event to the log file.'''
+        level = self.level_for_event(event)
+        if level < self.LOG_LEVEL_THRESHOLD:
+            return
+
+        data = {
+            "logger": self.logger_for_event(event),
+            "level": level,
+            "timestamp": time.time(),
+        }
+
+        failure = event.get('failure')
+        if failure:
+            data['class'] = repr(failure.type)
+            data['instance'] = repr(failure.value)
+            data['stack'] = failure.stack
+
+        data['message'] = log.textFromEventDict(event)
+
+        self.logfile.write(json.dumps(data))
+
+    def __call__(self, event):
+        if self.log_context_sentinel in event:
+            return
+        log.callWithContext(self.log_context, self._log_to_file, event)
+
+
+class JunebugLoggerService(Service):
+    '''Service for :class:`junebug.logging.JunebugLogObserver`'''
+
+    def __init__(self, worker_id, path, rotate, max_files, logger=None):
+        '''
+        Create the service for the Junebug Log Observer.
+
+        :param str worker_id: ID of the worker to observe logs for.
+        :param str path: Path to place the log files.
+        :param int rotate: Size (in bytes) before rotating log file.
+        :param int max_files:
+            Maximum amount of log files before old log files
+            start to get deleted.
+        :param logger:
+            logger to add observer to. Defaults to
+            twisted.python.log.theLogPublisher
+        :type logger: :class:`twisted.python.log.LogPublisher`
+        '''
+        self.setName('Junebug Worker Logger')
+        self.logger = logger if logger is not None else log.theLogPublisher
+        self.worker_id = worker_id
+        self.path = path
+        self.rotate = rotate
+        self.max_files = max_files
+
+    def startService(self):
+        self.logfile = LogFile(
+            self.worker_id, self.path, rotateLength=self.rotate,
+            maxRotatedFiles=self.max_files)
+        self.log_observer = JunebugLogObserver(self.logfile, self.worker_id)
+        self.logger.addObserver(self.log_observer)
+        return super(JunebugLoggerService, self).startService()
+
+    def stopService(self):
+        if self.running:
+            self.logger.removeObserver(self.log_observer)
+            self.logfile.close()
+        return super(JunebugLoggerService, self).stopService()
+
+    def registered(self):
+        return (
+            getattr(self, 'log_observer', None) and
+            self.log_observer in self.logger.observers)

--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -84,6 +84,7 @@ class JunebugLogObserver(object):
 
 class JunebugLoggerService(Service):
     '''Service for :class:`junebug.logging.JunebugLogObserver`'''
+    log_observer = None
 
     def __init__(self, worker_id, path, rotate, max_files, logger=None):
         '''
@@ -122,6 +123,4 @@ class JunebugLoggerService(Service):
         return super(JunebugLoggerService, self).stopService()
 
     def registered(self):
-        return (
-            getattr(self, 'log_observer', None) and
-            self.log_observer in self.logger.observers)
+        return self.log_observer in self.logger.observers

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -120,6 +120,13 @@ class TestSentryLogObserver(VumiTestCase):
             'level': logging.INFO
         })
 
+    def test_log_debug(self):
+        '''Logging a debug level log should not generate a log, since it is
+        below the minimum log level.'''
+        self.obs({'message': ["a"], 'system': 'foo',
+                  'logLevel': logging.DEBUG})
+        self.assertEqual(len(self.logfile.logs), 0)
+
 
 class TestJunebugLoggerSerivce(VumiTestCase):
 

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -127,6 +127,14 @@ class TestSentryLogObserver(VumiTestCase):
                   'logLevel': logging.DEBUG})
         self.assertEqual(len(self.logfile.logs), 0)
 
+    def test_log_with_context_sentinel(self):
+        '''If the context sentinel has been set for a log, it should not be
+        logged again.'''
+        event = {'message': ["a"], 'system': 'foo'}
+        event.update(self.obs.log_context)
+        self.obs(event)
+        self.assertEqual(len(self.logfile.logs), 0)
+
 
 class TestJunebugLoggerSerivce(VumiTestCase):
 

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -162,6 +162,9 @@ class TestJunebugLoggerService(JunebugTestBase):
     def test_logging(self):
         '''The logging service should write logs to the logfile when the
         service is running.'''
+        self.logger.msg("Hello")
+        self.assertFalse(hasattr(self.service, 'logfile'))
+
         yield self.service.startService()
         logfile = self.service.logfile
         self.logger.msg("Hello", logLevel=logging.WARN)

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -1,0 +1,182 @@
+import json
+import logging
+import sys
+
+from twisted.internet.defer import inlineCallbacks
+from twisted.python.failure import Failure
+from twisted.python.log import LogPublisher
+from vumi.tests.helpers import VumiTestCase
+
+import junebug
+from junebug.logging_service import JunebugLogObserver, JunebugLoggerService
+
+
+class DummyLogFile(object):
+    '''LogFile that just stores logs in memory in `logs`.'''
+    def __init__(
+            self, worker_id, path, rotateLength, maxRotatedFiles):
+        self.worker_id = worker_id
+        self.path = path
+        self.rotateLength = rotateLength
+        self.maxRotatedFiles = maxRotatedFiles
+        self.logs = []
+        self.closed_count = 0
+
+    def write(self, data):
+        self.logs.append(data)
+
+    def close(self):
+        self.closed_count += 1
+
+
+class TestSentryLogObserver(VumiTestCase):
+    def setUp(self):
+        self.logfile = DummyLogFile(None, None, None, None)
+        self.obs = JunebugLogObserver(self.logfile, 'worker-1')
+
+    def test_level_for_event(self):
+        '''The correct logging level is returned by `level_for_event`.'''
+        for expected_level, event in [
+            (logging.WARN, {'logLevel': logging.WARN}),
+            (logging.ERROR, {'isError': 1}),
+            (logging.INFO, {}),
+        ]:
+            self.assertEqual(self.obs.level_for_event(event), expected_level)
+
+    def test_logger_for_event(self):
+        '''The correct logger name is returned by `logger_for_event`.'''
+        self.assertEqual(self.obs.logger_for_event({'system': 'foo,bar'}),
+                         'worker-1.foo.bar')
+        self.assertEqual(self.obs.logger_for_event({}), 'worker-1')
+
+    def test_log_failure(self):
+        '''A failure should be logged with the correct format.'''
+        e = ValueError("foo error")
+        f = Failure(e)
+        self.obs({
+            'failure': f, 'system': 'foo', 'isError': 1,
+            'message': [e.message]})
+
+        [log] = self.logfile.logs
+        log = json.loads(log)
+        log.pop('timestamp')
+
+        self.assertEqual(log, {
+            'level': JunebugLogObserver.DEFAULT_ERROR_LEVEL,
+            'message': 'foo error',
+            'logger': 'worker-1.foo',
+            'class': repr(ValueError),
+            'instance': repr(e),
+            'stack': [],
+        })
+
+    def test_log_traceback(self):
+        '''Logging a log with a traceback should place the traceback in the
+        logfile.'''
+        try:
+            raise ValueError("foo")
+        except ValueError:
+            f = Failure(*sys.exc_info())
+        self.obs({'failure': f, 'isError': 1, 'message': ['foo']})
+        [log] = self.logfile.logs
+        log = json.loads(log)
+        log.pop('timestamp')
+        self.assertEqual(log, {
+            'message': 'foo',
+            'logger': 'worker-1',
+            'level': logging.ERROR,
+            'class': repr(f.type),
+            'instance': repr(ValueError),
+            # json encoding changes all tuples to lists
+            'stack': json.loads(json.dumps(f.stack)),
+        })
+
+    def test_log_warning(self):
+        '''Logging an warning level log should generate the correct level log
+        message'''
+        self.obs({'message': ["a"], 'system': 'foo',
+                  'logLevel': logging.WARN})
+        [log] = self.logfile.logs
+        log = json.loads(log)
+        log.pop('timestamp')
+
+        self.assertEqual(log, {
+            'level': logging.WARN,
+            'logger': 'worker-1.foo',
+            'message': 'a',
+        })
+
+    def test_log_info(self):
+        '''Logging an info level log should generate the correct level log
+        message'''
+        self.obs({'message': ["a"], 'system': 'test.log'})
+        [log] = self.logfile.logs
+        log = json.loads(log)
+        log.pop('timestamp')
+
+        self.assertEqual(log, {
+            'logger': 'worker-1.test.log',
+            'message': 'a',
+            'level': logging.INFO
+        })
+
+
+class TestJunebugLoggerSerivce(VumiTestCase):
+
+    def setUp(self):
+        self.patch(junebug.logging_service, 'LogFile', DummyLogFile)
+        self.logger = LogPublisher()
+        self.service = JunebugLoggerService(
+            'worker-id', '/testpath/', 1000000, 7, logger=self.logger)
+
+    @inlineCallbacks
+    def test_logfile_parameters(self):
+        '''When the logfile is created, it should be created with the correct
+        parameters.'''
+        yield self.service.startService()
+        logfile = self.service.logfile
+        self.assertEqual(logfile.worker_id, 'worker-id')
+        self.assertEqual(logfile.path, '/testpath/')
+        self.assertEqual(logfile.rotateLength, 1000000)
+        self.assertEqual(logfile.maxRotatedFiles, 7)
+
+    @inlineCallbacks
+    def test_logging(self):
+        '''The logging service should write logs to the logfile when the
+        service is running.'''
+        yield self.service.startService()
+        logfile = self.service.logfile
+        self.logger.msg("Hello", logLevel=logging.WARN)
+        [log] = logfile.logs
+        log = json.loads(log)
+        log.pop('timestamp')
+
+        self.assertEqual(log, {
+            'level': logging.WARN,
+            'logger': 'worker-id',
+            'message': 'Hello',
+        })
+
+        del logfile.logs[:]
+        yield self.service.stopService()
+        self.logger.msg("Foo", logLevel=logging.WARN)
+        self.assertEqual(logfile.logs, [])
+
+    @inlineCallbacks
+    def test_stop_not_running(self):
+        '''If stopService is called when the service is not running, there
+        should be no exceptions raised.'''
+        yield self.service.stopService()
+        self.assertFalse(self.service.running)
+
+    @inlineCallbacks
+    def test_start_stop(self):
+        '''Stopping the service after it has been started should result in
+        properly closing the logfile.'''
+        self.assertFalse(self.service.registered())
+        yield self.service.startService()
+        self.assertEqual(self.service.logfile.closed_count, 0)
+        self.assertTrue(self.service.registered())
+        yield self.service.stopService()
+        self.assertFalse(self.service.registered())
+        self.assertEqual(self.service.logfile.closed_count, 1)

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -5,9 +5,9 @@ import sys
 from twisted.internet.defer import inlineCallbacks
 from twisted.python.failure import Failure
 from twisted.python.log import LogPublisher
-from vumi.tests.helpers import VumiTestCase
 
 import junebug
+from junebug.tests.helpers import JunebugTestBase
 from junebug.logging_service import JunebugLogObserver, JunebugLoggerService
 
 
@@ -29,10 +29,17 @@ class DummyLogFile(object):
         self.closed_count += 1
 
 
-class TestSentryLogObserver(VumiTestCase):
+class TestSentryLogObserver(JunebugTestBase):
     def setUp(self):
         self.logfile = DummyLogFile(None, None, None, None)
         self.obs = JunebugLogObserver(self.logfile, 'worker-1')
+
+    def assert_log(self, log, expected):
+        '''Assert that a log matches what is expected.'''
+        log = json.loads(log)
+        timestamp = log.pop('timestamp')
+        self.assertTrue(isinstance(timestamp, float))
+        self.assertEqual(log, expected)
 
     def test_level_for_event(self):
         '''The correct logging level is returned by `level_for_event`.'''
@@ -58,10 +65,7 @@ class TestSentryLogObserver(VumiTestCase):
             'message': [e.message]})
 
         [log] = self.logfile.logs
-        log = json.loads(log)
-        log.pop('timestamp')
-
-        self.assertEqual(log, {
+        self.assert_log(log, {
             'level': JunebugLogObserver.DEFAULT_ERROR_LEVEL,
             'message': 'foo error',
             'logger': 'worker-1.foo',
@@ -79,9 +83,7 @@ class TestSentryLogObserver(VumiTestCase):
             f = Failure(*sys.exc_info())
         self.obs({'failure': f, 'isError': 1, 'message': ['foo']})
         [log] = self.logfile.logs
-        log = json.loads(log)
-        log.pop('timestamp')
-        self.assertEqual(log, {
+        self.assert_log(log, {
             'message': 'foo',
             'logger': 'worker-1',
             'level': logging.ERROR,
@@ -97,10 +99,7 @@ class TestSentryLogObserver(VumiTestCase):
         self.obs({'message': ["a"], 'system': 'foo',
                   'logLevel': logging.WARN})
         [log] = self.logfile.logs
-        log = json.loads(log)
-        log.pop('timestamp')
-
-        self.assertEqual(log, {
+        self.assert_log(log, {
             'level': logging.WARN,
             'logger': 'worker-1.foo',
             'message': 'a',
@@ -111,10 +110,7 @@ class TestSentryLogObserver(VumiTestCase):
         message'''
         self.obs({'message': ["a"], 'system': 'test.log'})
         [log] = self.logfile.logs
-        log = json.loads(log)
-        log.pop('timestamp')
-
-        self.assertEqual(log, {
+        self.assert_log(log, {
             'logger': 'worker-1.test.log',
             'message': 'a',
             'level': logging.INFO
@@ -136,13 +132,20 @@ class TestSentryLogObserver(VumiTestCase):
         self.assertEqual(len(self.logfile.logs), 0)
 
 
-class TestJunebugLoggerSerivce(VumiTestCase):
+class TestJunebugLoggerService(JunebugTestBase):
 
     def setUp(self):
         self.patch(junebug.logging_service, 'LogFile', DummyLogFile)
         self.logger = LogPublisher()
         self.service = JunebugLoggerService(
             'worker-id', '/testpath/', 1000000, 7, logger=self.logger)
+
+    def assert_log(self, log, expected):
+        '''Assert that a log matches what is expected.'''
+        log = json.loads(log)
+        timestamp = log.pop('timestamp')
+        self.assertTrue(isinstance(timestamp, float))
+        self.assertEqual(log, expected)
 
     @inlineCallbacks
     def test_logfile_parameters(self):
@@ -163,10 +166,8 @@ class TestJunebugLoggerSerivce(VumiTestCase):
         logfile = self.service.logfile
         self.logger.msg("Hello", logLevel=logging.WARN)
         [log] = logfile.logs
-        log = json.loads(log)
-        log.pop('timestamp')
 
-        self.assertEqual(log, {
+        self.assert_log(log, {
             'level': logging.WARN,
             'logger': 'worker-id',
             'message': 'Hello',


### PR DESCRIPTION
Create a logging service similar to `vumi.sentry.SentryLoggerService` that logs to a file instead of sentry, using `twisted.python.logfile` to assist with logfile rotation.