### PR TITLE
Start logger service with transport

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -270,6 +270,7 @@ class Channel(object):
         config = self._properties['config']
         config = self._convert_unicode(config)
         config['transport_name'] = self.id
+        config['worker_name'] = self.id
         config['publish_status'] = True
         return config
 

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -8,6 +8,7 @@ from vumi.message import TransportUserMessage
 from vumi.service import WorkerCreator
 from vumi.servicemaker import VumiOptions
 
+from junebug.logging_service import JunebugLoggerService
 from junebug.stores import StatusStore, MessageRateStore
 from junebug.utils import api_from_message, message_from_api, api_from_status
 from junebug.error import JunebugError
@@ -62,6 +63,7 @@ class Channel(object):
     STATUS_APPLICATION_ID = 'status:%s'
     APPLICATION_CLS_NAME = 'junebug.workers.MessageForwardingWorker'
     STATUS_APPLICATION_CLS_NAME = 'junebug.workers.ChannelStatusWorker'
+    JUNEBUG_LOGGING_SERVICE_CLS = JunebugLoggerService
 
     def __init__(self, redis_manager, config, properties, plugins=[], id=None):
         '''Creates a new channel. ``redis_manager`` is the redis manager, from
@@ -319,12 +321,17 @@ class Channel(object):
             transport_worker = self._create_transport()
 
         transport_worker.setName(self.id)
+
+        logging_service = self._create_junebug_logger_service()
+        transport_worker.addService(logging_service)
+
         transport_worker.setServiceParent(service)
         self.transport_worker = transport_worker
 
     def _start_application(self, service):
         worker = self._create_application()
         worker.setName(self.application_id)
+
         worker.setServiceParent(service)
         self.application_worker = worker
 
@@ -348,6 +355,11 @@ class Channel(object):
         return self._create_worker(
             self.STATUS_APPLICATION_CLS_NAME,
             self._status_application_config)
+
+    def _create_junebug_logger_service(self):
+        return JunebugLoggerService(
+            self.id, self.config.logging_path, self.config.log_rotate_size,
+            self.config.max_log_files)
 
     def _create_worker(self, cls_name, config):
         creator = WorkerCreator(self.options)

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -358,7 +358,7 @@ class Channel(object):
             self._status_application_config)
 
     def _create_junebug_logger_service(self):
-        return JunebugLoggerService(
+        return self.JUNEBUG_LOGGING_SERVICE_CLS(
             self.id, self.config.logging_path, self.config.log_rotate_size,
             self.config.max_log_files)
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -91,13 +91,13 @@ def create_parser():
         dest='logging_path', help='The path to place log files for each '
         'channel. Defaults to `logs/`')
     parser.add_argument(
-        '--log-rotate-size', '-lrs', type=str,
+        '--log-rotate-size', '-lrs', type=int,
         dest='log_rotate_size', help='The maximum size (in bytes) for each '
         'log file before it gets rotated. Defaults to 1000000.')
     parser.add_argument(
-        '--max-log-files', '-mlf', type=str,
+        '--max-log-files', '-mlf', type=int,
         dest='max_log_files', help='The maximum number of log files to '
-        'keep before deleting old files. Defaults to unlimited log files.')
+        'keep before deleting old files. Defaults to 5. 0 is unlimited.')
 
     return parser
 
@@ -152,7 +152,10 @@ def config_from_args(args):
     config['amqp'] = parse_amqp(config.get('amqp', {}), args)
     parse_channels(args)
     args['plugins'] = parse_plugins(config.get('plugins', []), args)
-    return JunebugConfig(conjoin(config, args))
+
+    combined = conjoin(config, args)
+    combined['max_log_files'] = combined.get('max_log_files') or None
+    return JunebugConfig(combined)
 
 
 def parse_redis(config, args):

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -154,7 +154,11 @@ def config_from_args(args):
     args['plugins'] = parse_plugins(config.get('plugins', []), args)
 
     combined = conjoin(config, args)
+
+    # max_log_files == 0 means that no limit should be set, so we need to set
+    # it to `None` for that case
     combined['max_log_files'] = combined.get('max_log_files') or None
+
     return JunebugConfig(combined)
 
 

--- a/junebug/command_line.py
+++ b/junebug/command_line.py
@@ -86,6 +86,18 @@ def create_parser():
         '--metric-window', '-mw', type=float,
         dest='metric_window', help='The size of each bucket '
         '(in seconds) to use for metrics. Defaults to 10 seconds.')
+    parser.add_argument(
+        '--logging-path', '-lp', type=str,
+        dest='logging_path', help='The path to place log files for each '
+        'channel. Defaults to `logs/`')
+    parser.add_argument(
+        '--log-rotate-size', '-lrs', type=str,
+        dest='log_rotate_size', help='The maximum size (in bytes) for each '
+        'log file before it gets rotated. Defaults to 1000000.')
+    parser.add_argument(
+        '--max-log-files', '-mlf', type=str,
+        dest='max_log_files', help='The maximum number of log files to '
+        'keep before deleting old files. Defaults to unlimited log files.')
 
     return parser
 

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -60,3 +60,14 @@ class JunebugConfig(Config):
 
     metric_window = ConfigFloat(
         "The size of the buckets (in seconds) used for metrics.", default=10.0)
+
+    logging_path = ConfigText(
+        "The path to place log files in.", default="logs/")
+
+    log_rotate_size = ConfigInt(
+        "The maximum size (in bytes) of a log file before it gets rotated.",
+        default=1000000)
+
+    max_log_files = ConfigInt(
+        "The maximum amount of log files allowed before old files start to "
+        "get deleted.", default=None)

--- a/junebug/config.py
+++ b/junebug/config.py
@@ -70,4 +70,4 @@ class JunebugConfig(Config):
 
     max_log_files = ConfigInt(
         "The maximum amount of log files allowed before old files start to "
-        "get deleted.", default=None)
+        "get deleted. 0 is unlimited.", default=5)

--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -50,7 +50,7 @@ class JunebugLogObserver(object):
         system = event.get('system', '-')
         parts = [self.worker_id]
         if system != '-':
-            parts.extend(system.split(','))
+            parts = system.split(',')
         logger = ".".join(parts)
         return logger.lower()
 
@@ -78,6 +78,8 @@ class JunebugLogObserver(object):
 
     def __call__(self, event):
         if self.log_context_sentinel in event:
+            return
+        if self.worker_id not in event.get('system', ''):
             return
         log.callWithContext(self.log_context, self._log_to_file, event)
 

--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -75,7 +75,7 @@ class JunebugLogObserver(object):
     def __call__(self, event):
         if self.log_context_sentinel in event:
             return
-        if self.worker_id not in event.get('system', ''):
+        if self.worker_id not in event.get('system', '').split(','):
             return
         log.callWithContext(self.log_context, self._log_to_file, event)
 

--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -47,11 +47,8 @@ class JunebugLogObserver(object):
 
     def logger_for_event(self, event):
         '''Get the name of the logger for an event.'''
-        system = event.get('system', '-')
-        parts = [self.worker_id]
-        if system != '-':
-            parts = system.split(',')
-        logger = ".".join(parts)
+        system = event.get('system')
+        logger = ".".join(system.split(','))
         return logger.lower()
 
     def _log_to_file(self, event):
@@ -64,6 +61,7 @@ class JunebugLogObserver(object):
             "logger": self.logger_for_event(event),
             "level": level,
             "timestamp": time.time(),
+            "message": log.textFromEventDict(event),
         }
 
         failure = event.get('failure')
@@ -71,8 +69,6 @@ class JunebugLogObserver(object):
             data['class'] = repr(failure.type)
             data['instance'] = repr(failure.value)
             data['stack'] = failure.stack
-
-        data['message'] = log.textFromEventDict(event)
 
         self.logfile.write(json.dumps(data))
 

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -12,7 +12,6 @@ from twisted.web.server import Site
 from klein import Klein
 from txamqp.client import TwistedDelegate
 
-from vumi import log
 from vumi.utils import vumi_resource_path
 from vumi.service import get_spec
 from vumi.tests.fake_amqp import FakeAMQPBroker, FakeAMQPChannel
@@ -82,6 +81,11 @@ class RequestLoggingApi(object):
             })
         request.setResponseCode(500)
         return 'test-error-response'
+
+
+class LoggingTestTransport(Transport):
+    def test_log(self, message='Test log'):
+        self.log.msg(message, source=self)
 
 
 class JunebugTestBase(TestCase):

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -173,15 +173,12 @@ class JunebugTestBase(TestCase):
         if config is None:
             config = yield self.create_channel_config(
                 channels={
-                    'test_channel': transport_class
+                    properties['type']: transport_class
                 })
 
-        patched_type = properties['type']
-        properties['type'] = 'test_channel'
         channel = Channel(
             redis, config, properties, id=id, plugins=plugins)
         yield channel.start(self.service)
-        properties['type'] = patched_type
 
         properties['config']['transport_name'] = channel.id
 

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -170,6 +170,7 @@ class TestJunebugApi(JunebugTestBase):
 
         self.assertEqual(transport.config, conjoin(properties['config'], {
             'transport_name': id,
+            'worker_name': id,
             'publish_status': True,
         }))
 

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -238,6 +238,19 @@ class TestChannel(JunebugTestBase):
 
         channel = yield self.create_channel(
             self.service, self.redis, plugins=[plugin])
+
+        [(name, [plugin_channel])] = plugin.calls
+        self.assertEqual(name, 'channel_started')
+        self.assertEqual(plugin_channel, channel)
+
+    @inlineCallbacks
+    def test_stop_channel_plugins_called(self):
+        '''Stopping a channel should call `channel_stopped` on all plugins'''
+        plugin = FakeJunebugPlugin()
+        plugin.calls = []
+
+        channel = yield self.create_channel(
+            self.service, self.redis, plugins=[plugin])
         plugin.calls = []
 
         yield channel.stop()

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -3,14 +3,12 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.message import TransportUserMessage, TransportStatus
 from vumi.transports.telnet import TelnetServerTransport
 
-import junebug
 from junebug.utils import api_from_message, api_from_status, conjoin
 from junebug.workers import ChannelStatusWorker, MessageForwardingWorker
 from junebug.channel import (
     Channel, ChannelNotFound, InvalidChannelType, MessageNotFound)
 from junebug.logging_service import JunebugLoggerService
 from junebug.tests.helpers import JunebugTestBase, FakeJunebugPlugin
-from junebug.tests.test_logging_service import DummyLogFile
 
 
 class TestChannel(JunebugTestBase):
@@ -75,7 +73,6 @@ class TestChannel(JunebugTestBase):
     def test_start_channel_logging(self):
         '''When the channel is started, the logging worker should be started
         along with it.'''
-        self.patch(junebug.logging_service, 'LogFile', DummyLogFile)
         channel = yield self.create_channel(
             self.service, self.redis,
             'junebug.tests.helpers.LoggingTestTransport')
@@ -87,7 +84,6 @@ class TestChannel(JunebugTestBase):
     @inlineCallbacks
     def test_channel_logging_single_channel(self):
         '''All logs from a single channel should go to the logging worker.'''
-        self.patch(junebug.logging_service, 'LogFile', DummyLogFile)
         channel = yield self.create_channel(
             self.service, self.redis,
             'junebug.tests.helpers.LoggingTestTransport')
@@ -104,7 +100,6 @@ class TestChannel(JunebugTestBase):
     @inlineCallbacks
     def test_channel_logging_multiple_channels(self):
         '''All logs from a single channel should go to the logging worker.'''
-        self.patch(junebug.logging_service, 'LogFile', DummyLogFile)
         channel1 = yield self.create_channel(
             self.service, self.redis,
             'junebug.tests.helpers.LoggingTestTransport')

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -55,12 +55,18 @@ class TestChannel(JunebugTestBase):
 
     @inlineCallbacks
     def test_start_channel_transport(self):
+        '''Starting the channel should start the transport, as well as the
+        logging service for that transport.'''
         channel = yield self.create_channel(
             self.service, self.redis, TelnetServerTransport)
 
-        self.assertEqual(
-            self.service.namedServices[channel.id],
-            channel.transport_worker)
+        worker = self.service.getServiceNamed(channel.id)
+        self.assertEqual(worker, channel.transport_worker)
+        self.assertTrue(isinstance(worker, TelnetServerTransport))
+
+        logging_worker = worker.getServiceNamed('Junebug Worker Logger')
+        self.assertTrue(
+            isinstance(logging_worker, channel.JUNEBUG_LOGGING_SERVICE_CLS))
 
     @inlineCallbacks
     def test_transport_class_name_default(self):

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -263,6 +263,40 @@ class TestCommandLine(JunebugTestBase):
         config = parse_arguments(['-mw', '2.0'])
         self.assertEqual(config.metric_window, 2.0)
 
+    def test_parse_arguments_logging_path(self):
+        '''The logging path can be specified by "--logging-path" or "-lp"'''
+        config = parse_arguments([])
+        self.assertEqual(config.logging_path, 'logs/')
+
+        config = parse_arguments(['--logging-path', 'other-logs/'])
+        self.assertEqual(config.logging_path, 'other-logs/')
+
+        config = parse_arguments(['-lp', 'other-logs/'])
+        self.assertEqual(config.logging_path, 'other-logs/')
+
+    def test_parse_arguments_log_rotate_size(self):
+        '''The log rotate size can be specified by "--log-rotate-size" or
+        "-lrs"'''
+        config = parse_arguments([])
+        self.assertEqual(config.log_rotate_size, 1000000)
+
+        config = parse_arguments(['--log-rotate-size', '7'])
+        self.assertEqual(config.log_rotate_size, 7)
+
+        config = parse_arguments(['-lrs', '7'])
+        self.assertEqual(config.log_rotate_size, 7)
+
+    def test_parse_arguments_max_log_files(self):
+        '''The max log files can be specified by "--max-log-files" or "-mlf"'''
+        config = parse_arguments([])
+        self.assertEqual(config.max_log_files, None)
+
+        config = parse_arguments(['--max-log-files', '2'])
+        self.assertEqual(config.max_log_files, 2)
+
+        config = parse_arguments(['-mlf', '2'])
+        self.assertEqual(config.max_log_files, 2)
+
     def test_config_file(self):
         '''The config file command line argument can be specified by
         "--config" or "-c"'''
@@ -289,6 +323,9 @@ class TestCommandLine(JunebugTestBase):
                 'channels': {'foo': 'bar'},
                 'plugins': [{'type': 'foo.bar'}],
                 'metric_window': 2.0,
+                'logging_path': 'other-logs/',
+                'log_rotate_size': 2,
+                'max_log_files': 3,
             }
         })
 
@@ -310,6 +347,9 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.channels, {'foo': 'bar'})
         self.assertEqual(config.plugins, [{'type': 'foo.bar'}])
         self.assertEqual(config.metric_window, 2.0)
+        self.assertEqual(config.logging_path, 'other-logs/')
+        self.assertEqual(config.log_rotate_size, 2)
+        self.assertEqual(config.max_log_files, 3)
 
         config = parse_arguments(['-c', '/foo/bar.yaml'])
         self.assertEqual(config.interface, 'lolcathost')
@@ -329,6 +369,9 @@ class TestCommandLine(JunebugTestBase):
         self.assertEqual(config.channels, {'foo': 'bar'})
         self.assertEqual(config.plugins, [{'type': 'foo.bar'}])
         self.assertEqual(config.metric_window, 2.0)
+        self.assertEqual(config.logging_path, 'other-logs/')
+        self.assertEqual(config.log_rotate_size, 2)
+        self.assertEqual(config.max_log_files, 3)
 
     def test_config_file_overriding(self):
         '''Config file options are overriden by their corresponding command
@@ -353,6 +396,9 @@ class TestCommandLine(JunebugTestBase):
                 },
                 'plugins': [{'type': 'foo.bar'}],
                 'metric_window': 2.0,
+                'logging_path': 'other-logs/',
+                'log_rotate_size': 2,
+                'max_log_files': 3,
             }
         })
 
@@ -372,6 +418,9 @@ class TestCommandLine(JunebugTestBase):
             '-amqppass', 'kodama',
             '-pl', json.dumps({'type': 'bar.foo'}),
             '-mw', '3.0',
+            '-lp', 'my-logs/',
+            '-lrs', '100',
+            '-mlf', '10',
         ])
 
         self.assertEqual(config.interface, 'zuulcathost')
@@ -391,6 +440,9 @@ class TestCommandLine(JunebugTestBase):
             {'type': 'foo.bar'}
         ])
         self.assertEqual(config.metric_window, 3.0)
+        self.assertEqual(config.logging_path, 'my-logs/')
+        self.assertEqual(config.log_rotate_size, 100)
+        self.assertEqual(config.max_log_files, 10)
 
     def test_logging_setup(self):
         '''If filename is None, just a stdout logger is created, if filename

--- a/junebug/tests/test_command_line.py
+++ b/junebug/tests/test_command_line.py
@@ -297,6 +297,12 @@ class TestCommandLine(JunebugTestBase):
         config = parse_arguments(['-mlf', '2'])
         self.assertEqual(config.max_log_files, 2)
 
+        config = parse_arguments(['--max-log-files', '0'])
+        self.assertEqual(config.max_log_files, None)
+
+        config = parse_arguments(['-mlf', '0'])
+        self.assertEqual(config.max_log_files, None)
+
     def test_config_file(self):
         '''The config file command line argument can be specified by
         "--config" or "-c"'''

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -118,11 +118,14 @@ class TestSentryLogObserver(JunebugTestBase):
     def test_log_only_worker_id(self):
         '''A log should only be created when the worker id is in the system
         id of the log.'''
-        self.obs({'message': ["a"], 'system': 'worker-1'})
+        self.obs({'message': ["a"], 'system': 'worker-1,bar'})
         self.assertEqual(len(self.logfile.logs), 1)
         del self.logfile.logs[:]
 
-        self.obs({'message': ["a"], 'system': 'worker-2'})
+        self.obs({'message': ["a"], 'system': 'worker-2,foo'})
+        self.assertEqual(len(self.logfile.logs), 0)
+
+        self.obs({'message': ["a"], 'system': 'worker-1foo,bar'})
         self.assertEqual(len(self.logfile.logs), 0)
 
 

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -52,9 +52,8 @@ class TestSentryLogObserver(JunebugTestBase):
 
     def test_logger_for_event(self):
         '''The correct logger name is returned by `logger_for_event`.'''
-        self.assertEqual(self.obs.logger_for_event({'system': 'foo,bar'}),
-                         'foo.bar')
-        self.assertEqual(self.obs.logger_for_event({}), 'worker-1')
+        self.assertEqual(self.obs.logger_for_event(
+            {'system': 'foo,bar'}), 'foo.bar')
 
     def test_log_failure(self):
         '''A failure should be logged with the correct format.'''

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -7,26 +7,8 @@ from twisted.python.failure import Failure
 from twisted.python.log import LogPublisher
 
 import junebug
-from junebug.tests.helpers import JunebugTestBase
+from junebug.tests.helpers import JunebugTestBase, DummyLogFile
 from junebug.logging_service import JunebugLogObserver, JunebugLoggerService
-
-
-class DummyLogFile(object):
-    '''LogFile that just stores logs in memory in `logs`.'''
-    def __init__(
-            self, worker_id, path, rotateLength, maxRotatedFiles):
-        self.worker_id = worker_id
-        self.path = path
-        self.rotateLength = rotateLength
-        self.maxRotatedFiles = maxRotatedFiles
-        self.logs = []
-        self.closed_count = 0
-
-    def write(self, data):
-        self.logs.append(data)
-
-    def close(self):
-        self.closed_count += 1
 
 
 class TestSentryLogObserver(JunebugTestBase):

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -315,7 +315,8 @@ class TestStatusStore(JunebugTestBase):
     def test_store_single_status(self):
         '''The single status is stored under the correct key'''
         store = yield self.create_store()
-        status = TransportStatus(status='ok', component='foo')
+        status = TransportStatus(
+            status='ok', component='foo', type='bar', message='foo')
         yield store.store_status('channelid', status)
 
         status_redis = yield self.redis.hget('channelid:status', 'foo')
@@ -328,9 +329,12 @@ class TestStatusStore(JunebugTestBase):
         '''New statuses override old statuses with the same component, but do
         not affect statuses of different components'''
         store = yield self.create_store()
-        status_old = TransportStatus(status='ok', component='foo')
-        status_new = TransportStatus(status='down', component='foo')
-        status_other = TransportStatus(status='ok', component='bar')
+        status_old = TransportStatus(
+            status='ok', component='foo', type='bar', message='foo')
+        status_new = TransportStatus(
+            status='down', component='foo', type='bar', message='foo')
+        status_other = TransportStatus(
+            status='ok', component='bar', type='bar', message='foo')
 
         yield store.store_status('channelid', status_other)
         yield store.store_status('channelid', status_old)
@@ -345,7 +349,8 @@ class TestStatusStore(JunebugTestBase):
     @inlineCallbacks
     def test_load_one_status(self):
         store = yield self.create_store()
-        status = TransportStatus(status='ok', component='foo')
+        status = TransportStatus(
+            status='ok', component='foo', type='bar', message='foo')
         yield store.store_status('channelid', status)
 
         stored_statuses = yield store.get_statuses('channelid')
@@ -358,7 +363,8 @@ class TestStatusStore(JunebugTestBase):
         store = yield self.create_store()
         expected = {}
         for i in range(5):
-            status = TransportStatus(status='ok', component=i)
+            status = TransportStatus(
+                status='ok', component=i, type='bar', message='foo')
             yield store.store_status('channelid', status)
             expected[str(i)] = status
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'klein',
         'jsonschema',
         'treq',
-        'vumi',
+        'vumi>=0.5.33',
         'confmodel',
         'PyYAML',
     ],


### PR DESCRIPTION
When the transport is started, we should add the logger service to it (created in https://github.com/praekelt/junebug/pull/66) so that it can capture the logs of the worker.