### PR TITLE
Bug fixes

### DIFF
--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -79,7 +79,7 @@ class JunebugLogObserver(object):
     def __call__(self, event):
         if self.log_context_sentinel in event:
             return
-        if self.worker_id not in event.get('system', '').split(','):
+        if self.worker_id not in (event.get('system', '') or '').split(','):
             return
         log.callWithContext(self.log_context, self._log_to_file, event)
 

--- a/junebug/logging_service.py
+++ b/junebug/logging_service.py
@@ -79,7 +79,7 @@ class JunebugLogObserver(object):
     def __call__(self, event):
         if self.log_context_sentinel in event:
             return
-        if self.worker_id not in (event.get('system', '') or '').split(','):
+        if self.worker_id not in (event.get('system') or '').split(','):
             return
         log.callWithContext(self.log_context, self._log_to_file, event)
 

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -1,3 +1,4 @@
+from math import ceil
 import time
 from twisted.internet.defer import inlineCallbacks, returnValue
 
@@ -185,7 +186,7 @@ class MessageRateStore(BaseStore):
         Note: bucket_size should be kept constant for each channel_id and label
         combination. Changing bucket sizes results in undefined behaviour.'''
         key = self._get_current_key(channel_id, label, bucket_size)
-        return self.increment_id(key, ttl=bucket_size * 2)
+        return self.increment_id(key, ttl=int(ceil(bucket_size * 2)))
 
     @inlineCallbacks
     def get_messages_per_second(self, channel_id, label, bucket_size):

--- a/junebug/tests/test_logging_service.py
+++ b/junebug/tests/test_logging_service.py
@@ -134,6 +134,9 @@ class TestSentryLogObserver(JunebugTestBase):
         self.obs({'message': ["a"], 'system': 'worker-1foo,bar'})
         self.assertEqual(len(self.logfile.logs), 1)
 
+        self.obs({'message': ["a"], 'system': None})
+        self.assertEqual(len(self.logfile.logs), 1)
+
 
 class TestJunebugLoggerService(JunebugTestBase):
 

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -446,18 +446,20 @@ class TestMessageRateStore(JunebugTestBase):
 
         self.redis._client.clock = clock
 
-        yield store.increment('channelid', 'inbound', 1)
+        yield store.increment('channelid', 'inbound', 1.2)
         bucket0 = store.get_key('channelid', 'inbound', int(clock.seconds()))
         self.assertEqual((yield self.redis.get(bucket0)), '1')
 
-        clock.advance(1)
-        yield store.increment('channelid', 'inbound', 1)
+        clock.advance(1.2)
+        yield store.increment('channelid', 'inbound', 1.2)
         bucket1 = store.get_key('channelid', 'inbound', int(clock.seconds()))
         self.assertEqual((yield self.redis.get(bucket0)), '1')
         self.assertEqual((yield self.redis.get(bucket1)), '1')
 
-        clock.advance(1)
-        yield store.increment('channelid', 'inbound', 1)
+        # We need to advance the clock here by 1.8, as the expiry time is an
+        # int, and is rounded up.
+        clock.advance(1.8)
+        yield store.increment('channelid', 'inbound', 1.2)
         bucket2 = store.get_key('channelid', 'inbound', int(clock.seconds()))
         self.assertEqual((yield self.redis.get(bucket0)), None)
         self.assertEqual((yield self.redis.get(bucket1)), '1')


### PR DESCRIPTION
Two bugs that were found in practice:

Redis ttl needs to be an int, so we need to round up and convert the float to an int.

If the system is `None`, we shouldn't have an exception, we should just not log anything.