### PR TITLE
Add MANIFEST so that we can include package data in releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /docs/_build/*
+/build
+/dist
 *.pyc
 junebug.egg-info
 _trial_temp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,22 @@
+# Source distribution files.
+include .travis.yml
+include CONTRIBUTING.rst
+include docker-compose.yml
+include Dockerfile
+include LICENSE
+include README.rst
+include requirements-docs.txt
+include requirements.txt
+include setup.py
+
+recursive-include docs *
+prune docs/_build
+recursive-include example-app *
+prune example-app/channel-logs
+recursive-include utils *.sh
+
+# Python package data files.
+recursive-include junebug *.template
+
+# Prune stray bytecode files.
+global-exclude *.pyc


### PR DESCRIPTION
Currently `pip install junebug` leaves one with:
```
$ ls /lib/python2.7/site-packages/junebug/plugins/nginx 

__init__.py  __init__.pyc  plugin.py  plugin.pyc  tests
```