### PR TITLE
web_path and web_port parameters read from wrong places in the config

### DIFF
--- a/junebug/plugins/nginx/tests/test_plugin.py
+++ b/junebug/plugins/nginx/tests/test_plugin.py
@@ -124,9 +124,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': locations_dirname
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         chan4 = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -161,9 +162,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': self.make_temp_dir()
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         chan4 = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -189,9 +191,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': locations_dirname
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         channel = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -219,9 +222,10 @@ class TestNginxPlugin(JunebugTestBase):
             'location_template': location_template_filename
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         channel = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -243,9 +247,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': locations_dirname
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         channel = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -308,9 +313,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': self.make_temp_dir()
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         channel = yield self.create_channel(
             self.service, self.redis, properties=properties)
@@ -359,9 +365,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': locations_dirname
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         channel = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -387,9 +394,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': locations_dirname
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         chan4 = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)
@@ -425,9 +433,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': self.make_temp_dir()
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         channel = yield self.create_channel(
             self.service, self.redis, properties=properties)
@@ -448,9 +457,10 @@ class TestNginxPlugin(JunebugTestBase):
             'locations_dir': self.make_temp_dir()
         }, JunebugConfig({}))
 
-        properties = self.create_channel_properties(
-            web_path='/foo/bar',
-            web_port=2323)
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
 
         chan4 = yield self.create_channel(
             self.service, self.redis, id='chan4', properties=properties)

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -159,6 +159,8 @@ class JunebugTestBase(TestCase):
 
     def create_channel_properties(self, **kw):
         properties = deepcopy(self.default_channel_properties)
+        config = kw.pop('config', {})
+        properties['config'].update(config)
         properties.update(kw)
         return properties
 

--- a/junebug/tests/test_utils.py
+++ b/junebug/tests/test_utils.py
@@ -302,12 +302,14 @@ class TestUtils(TestCase):
 
     def test_public_http_properties_explicit(self):
         result = channel_public_http_properties({
-            'web_path': '/baz/quux',
-            'web_port': 2121,
+            'config': {
+                'web_path': '/baz/quux',
+                'web_port': 2121,
+            },
             'public_http': {
                 'web_path': '/foo/bar',
                 'web_port': 2323,
-            }
+            },
         })
 
         self.assertEqual(result, {
@@ -354,8 +356,12 @@ class TestUtils(TestCase):
 
     def test_public_http_properties_explicit_implicit_path(self):
         result = channel_public_http_properties({
-            'web_path': '/foo/bar',
-            'public_http': {'web_port': 2323}
+            'config': {
+                'web_path': '/foo/bar',
+            },
+            'public_http': {
+                'web_port': 2323
+            },
         })
 
         self.assertEqual(result, {
@@ -366,8 +372,12 @@ class TestUtils(TestCase):
 
     def test_public_http_properties_explicit_implicit_port(self):
         result = channel_public_http_properties({
-            'web_port': 2323,
-            'public_http': {'web_path': '/foo/bar'}
+            'config': {
+                'web_port': 2323,
+            },
+            'public_http': {
+                'web_path': '/foo/bar',
+            },
         })
 
         self.assertEqual(result, {
@@ -378,8 +388,10 @@ class TestUtils(TestCase):
 
     def test_public_http_properties_implicit(self):
         result = channel_public_http_properties({
-            'web_port': 2323,
-            'web_path': '/foo/bar'
+            'config': {
+                'web_port': 2323,
+                'web_path': '/foo/bar',
+            },
         })
 
         self.assertEqual(result, {

--- a/junebug/utils.py
+++ b/junebug/utils.py
@@ -130,10 +130,11 @@ def _api_from_event_dr(channel_id, event):
 
 
 def channel_public_http_properties(properties):
+    config = properties.get('config', {})
     results = conjoin({
         'enabled': True,
-        'web_path': properties.get('web_path'),
-        'web_port': properties.get('web_port'),
+        'web_path': config.get('web_path'),
+        'web_port': config.get('web_port'),
     }, properties.get('public_http', {}))
 
     if results['web_path'] is None or results['web_port'] is None:


### PR DESCRIPTION
https://github.com/praekelt/junebug/blob/develop/junebug/utils.py#L132 returns `None` for 
```
{
  "type": "smpp",
  "amqp_queue": "queue",
  "config": {
    "web_path": "/api",
    "web_port": 8051,
  }
}
```

Instead I have to duplicate the info as a top level key in the config:

```
{
  "type": "smpp",
  "amqp_queue": "queue",
  "public_http": {
    "enabled": true,
    "web_path": "/api",
    "web_port": 8051
  },
  "config": {
    "web_path": "/api",
    "web_port": 8051,
  }
}
```

This seems odd?