### PR TITLE
Allow for channel restarts.

### DIFF
--- a/docs/http_api.rst
+++ b/docs/http_api.rst
@@ -169,6 +169,11 @@ Channels
    Delete a channel.
 
 
+.. http:post:: /channels/(channel_id:str)/restart
+
+   Restart a channel.
+
+
 Logs
 ^^^^
 

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -204,6 +204,16 @@ class JunebugApi(object):
         returnValue(response(
             request, 'channel deleted', {}))
 
+    @app.route('/channels/<string:channel_id>/restart', methods=['POST'])
+    @inlineCallbacks
+    def restart_channel(self, request, channel_id):
+        '''Restart a channel.'''
+        channel = yield Channel.from_id(
+            self.redis, self.config, channel_id, self.service, self.plugins)
+        yield channel.stop()
+        yield channel.start(self.service)
+        returnValue(response(request, 'channel restarted', {}))
+
     @app.route('/channels/<string:channel_id>/logs', methods=['GET'])
     @inlineCallbacks
     def get_logs(self, request, channel_id):


### PR DESCRIPTION
Channels can be reconfigured by POST-ing to the channel resource. Depending on what values are changed, a restart may be the result.

It would be nice if a simple POST resulted in a restart to deal with transports that've disconnected. Currently the only way to achieve that is to restart all of Junebug with all configured channels.