### PR TITLE
Add leading / to web_paths for nginx plugin.

### DIFF
--- a/junebug/plugins/nginx/plugin.py
+++ b/junebug/plugins/nginx/plugin.py
@@ -100,6 +100,7 @@ class NginxPlugin(JunebugPlugin):
 
     def get_location_context(self, properties):
         web_path = properties['web_path']
+        web_path = '/%s' % web_path.lstrip('/')
         base_url = 'http://localhost:%s' % (properties['web_port'],)
 
         return {

--- a/junebug/plugins/nginx/tests/test_plugin.py
+++ b/junebug/plugins/nginx/tests/test_plugin.py
@@ -474,3 +474,27 @@ class TestNginxPlugin(JunebugTestBase):
         plugin.channel_stopped(chan4)
         plugin.channel_stopped(chan5)
         self.assertEqual(self.nginx_reloads(), 1)
+
+    def test_get_location_context(self):
+        plugin = NginxPlugin()
+        properties = self.create_channel_properties(config={
+            'web_path': '/foo/bar',
+            'web_port': 2323,
+        })
+        context = plugin.get_location_context(properties['config'])
+        self.assertEqual(context, {
+            'external_path': '/foo/bar',
+            'internal_url': 'http://localhost:2323/foo/bar',
+        })
+
+    def test_get_location_context_prepends_slash(self):
+        plugin = NginxPlugin()
+        properties = self.create_channel_properties(config={
+            'web_path': 'foo/bar',
+            'web_port': 2323,
+        })
+        context = plugin.get_location_context(properties['config'])
+        self.assertEqual(context, {
+            'external_path': '/foo/bar',
+            'internal_url': 'http://localhost:2323/foo/bar',
+        })


### PR DESCRIPTION
Channels that require a `web_path` don't need the `web_path` to have a leading `/` because the `web_path` is always considered to be relative to the root of the site. Nginx's location directives, however, do require a leading `/` since they're reading as a raw path prefix.

E.g. If `web_path` is `foo` we currently generate an Nginx config that looks like:
```
location foo { ... }
```
when we should be generating a config that looks like:
```
location /foo { ... }
```