### PR TITLE
API Errors don't say what key is the problem

### DIFF
--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -204,10 +204,14 @@ class TestJunebugApi(JunebugTestBase):
                     {
                         'message': '-3 is less than the minimum of 0',
                         'type': 'invalid_body',
+                        'schema_path': [
+                            'properties', 'rate_limit_count', 'minimum'],
                     },
                     {
                         'message': "u'a' is not of type 'integer'",
                         'type': 'invalid_body',
+                        'schema_path': [
+                            'properties', 'character_limit', 'type'],
                     },
                 ])
             })
@@ -319,10 +323,14 @@ class TestJunebugApi(JunebugTestBase):
                     {
                         'message': '-3 is less than the minimum of 0',
                         'type': 'invalid_body',
+                        'schema_path': [
+                            'properties', 'rate_limit_count', 'minimum'],
                     },
                     {
                         'message': "u'a' is not of type 'integer'",
                         'type': 'invalid_body',
+                        'schema_path': [
+                            'properties', 'character_limit', 'type'],
                     },
                 ]
             })
@@ -556,6 +564,7 @@ class TestJunebugApi(JunebugTestBase):
                     'message': "Additional properties are not allowed (u'foo' "
                     "was unexpected)",
                     'type': 'invalid_body',
+                    'schema_path': ['additionalProperties'],
                 }]
             })
 

--- a/junebug/tests/test_validate.py
+++ b/junebug/tests/test_validate.py
@@ -85,7 +85,8 @@ class TestValidate(TestCase):
         self.assertEqual(content['result'], {
             'errors': [{
                 'type': 'invalid_body',
-                'message': "23 is not of type 'string'"
+                'message': "23 is not of type 'string'",
+                'schema_path': ['properties', 'foo', 'type'],
             }]
         })
         self.assertEqual(content['status'], 400)

--- a/junebug/validate.py
+++ b/junebug/validate.py
@@ -34,7 +34,8 @@ def body_schema(schema):
     def validator(req, body, *a, **kw):
         return [{
             'type': 'invalid_body',
-            'message': e.message
+            'message': e.message,
+            'schema_path': list(e.schema_path),
         } for e in json_validator.iter_errors(body)]
 
     return validator


### PR DESCRIPTION
When making a POST to change multiple fields on a channel that generates multiple errors the response does not indicate what fields caused the errors. For example when trying to set multiple fields to `null` the following response was generated:

```json
{
  "status": 400,
  "code": "Bad Request",
  "description": "api usage error",
  "result": {
    "errors": [
      {
        "message": "None is not of type 'string'",
        "type": "invalid_body"
      },
      {
        "message": "None is not of type 'string'",
        "type": "invalid_body"
      }
    ]
  }
}
```