### PR TITLE
Fix MessageForwardingWorker teardown

### DIFF
--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -71,7 +71,8 @@ class MessageForwardingWorker(ApplicationWorker):
 
     @inlineCallbacks
     def teardown_application(self):
-        yield self.redis.close_manager()
+        if getattr(self, 'redis', None) is not None:
+            yield self.redis.close_manager()
 
     @property
     def channel_id(self):


### PR DESCRIPTION
Currently, the teardown_application method of the MessageForwardingWorker assumes that it has a redis manager, which won't be the case if the application didn't start up properly. We should add a safeguard against this.