### PR TITLE
Better handling for 301 responses

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -82,11 +82,17 @@ class JunebugApi(object):
 
     @app.handle_errors(HTTPException)
     def http_error(self, request, failure):
+        error = {
+            'code': failure.value.code,
+            'type': failure.value.name,
+            'message': failure.getErrorMessage(),
+        }
+        if getattr(failure.value, 'new_url', None) is not None:
+            request.setHeader('Location', failure.value.new_url)
+            error['new_url'] = failure.value.new_url
+
         return response(request, failure.value.description, {
-            'errors': [{
-                'type': failure.value.name,
-                'message': failure.getErrorMessage(),
-                }]
+            'errors': [error],
             }, code=failure.value.code)
 
     @app.handle_errors

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -55,10 +55,29 @@ class TestJunebugApi(JunebugTestBase):
             'The requested URL was not found on the server.  If you entered '
             'the URL manually please check your spelling and try again.', {
                 'errors': [{
+                    'code': 404,
                     'message': '404: Not Found',
                     'type': 'Not Found',
                     }]
                 })
+
+    @inlineCallbacks
+    def test_redirect_http_error(self):
+        resp = yield self.get('/channels')
+        [redirect] = resp.history()
+        yield self.assert_response(
+            redirect, http.MOVED_PERMANENTLY,
+            None, {
+                'errors': [{
+                    'code': 301,
+                    'message': '301: Moved Permanently',
+                    'type': 'Moved Permanently',
+                    'new_url': '%s/channels/' % self.url,
+                }],
+            })
+        yield self.assert_response(
+            resp, http.OK,
+            'channels listed', [])
 
     @inlineCallbacks
     def test_startup_plugins_started(self):


### PR DESCRIPTION
A 301 response currently looks like:

```{"status": 301, "code": "Moved Permanently", "description": null, "result": {"errors": [{"message": "301: Moved Permanently", "type": "Moved Permanently"}]}}```

We should at minimum include the URL that we are redirecting to.

Also, we should check that the headers are also being set correctly.