### PR TITLE
Add libssl-dev and libffi-dev to install instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,11 +3,20 @@
 Installation
 ============
 
-Junebug requires `Python`_ (version 2.6 or 2.7) to be installed. This installation method also requires `pip`_. Both of these must be installed before following the installation steps below.
+Junebug requires `Python`_ (version 2.6 or 2.7) to be installed. This
+installation method also requires `pip`_. Both of these must be installed before
+following the installation steps below.
 
-Junebug also needs `Redis`_ and `RabbitMQ`_. On Debian-based systems one can install them using::
+Junebug also needs `Redis`_ and `RabbitMQ`_. On Debian-based systems, one can
+install them using::
 
    $ apt-get install redis-server rabbitmq-server
+
+The Python cryptography library that Junebug depends on requires that the SSL
+and FFI library headers be installed. On Debian-based systems, one can install
+these using::
+
+   $ apt-get install libssl-dev libffi-dev
 
 Junebug can be then installed using::
 


### PR DESCRIPTION
Installing Junebug requires libssl-dev and libffi-dev to be present on Debian systems, so our install documents should mention those in the list of packages to apt-get install.