### PR TITLE
Specify minimum twisted version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ matrix:
     # Test on pypy without coverage, because it's unnecessary and very slow.
     - python: "pypy"
       env: PYPY_VERSION="4.0.1" NO_COVERAGE=1
+    # Test against the lowest version of Twisted that we claim to support
+    - python: "2.7"
+      env: TWISTED_VERSION="Twisted==15.0.0"
 before_install:
   - if [ ! -z "$PYPY_VERSION" ]; then source utils/setup-pypy-travis.sh; fi
 install:
+  - "pip install ${TWISTED_VERSION}"
   - "pip install -r requirements.txt"
   - "pip install coveralls"
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       env: PYPY_VERSION="4.0.1" NO_COVERAGE=1
     # Test against the lowest version of Twisted that we claim to support
     - python: "2.7"
-      env: TWISTED_VERSION="Twisted==15.0.0"
+      env: TWISTED_VERSION="Twisted==15.3.0"
 before_install:
   - if [ ! -z "$PYPY_VERSION" ]; then source utils/setup-pypy-travis.sh; fi
 install:

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
         'klein',
         'jsonschema',
         'treq',
+        # We install a newer version of twisted before vumi, since vumi has a
+        # lower minimum version requirement.
+        'Twisted>=15.0.0',
         'vumi>=0.5.33',
         'confmodel',
         'PyYAML',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'treq',
         # We install a newer version of twisted before vumi, since vumi has a
         # lower minimum version requirement.
-        'Twisted>=15.0.0',
+        'Twisted>=15.3.0',
         'vumi>=0.5.33',
         'confmodel',
         'PyYAML',


### PR DESCRIPTION
The minimum twisted version that `vumi` has is `13.2.0`, which is too low, since we rely on new style classes in Junebug. We set a minimum version (`15.0`), and also run our travis tests against our minimum version.