### PR TITLE
Don't store events without user_message_id

### DIFF
--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -136,6 +136,25 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.assertEqual(dispatched_msg, msg)
 
     @inlineCallbacks
+    def test_forward_event_no_message_id(self):
+        '''
+        If we receive an event, and we don't have a message ID to associate
+        the event to, then we should log the event and carry on.
+        '''
+        self.patch_logger()
+
+        event = TransportEvent(
+            event_type='ack',
+            user_message_id=None,
+            sent_message_id='msg-21',
+            timestamp='2015-09-22 15:39:44.827794')
+
+        yield self.worker.consume_ack(event)
+        self.assert_was_logged('Cannot store event')
+        self.assert_was_logged('Cannot find event URL')
+        self.assert_was_logged('%r' % event)
+
+    @inlineCallbacks
     def test_forward_ack_http(self):
         event = TransportEvent(
             event_type='ack',

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -125,7 +125,12 @@ class MessageForwardingWorker(ApplicationWorker):
     def _store_event(self, event):
         '''Stores the event in the message store'''
         message_id = event['user_message_id']
-        return self.outbounds.store_event(self.channel_id, message_id, event)
+        if message_id is None:
+            logging.warning(
+                "Cannot store event, missing user_message_id: %r" % event)
+        else:
+            return self.outbounds.store_event(
+                self.channel_id, message_id, event)
 
     @inlineCallbacks
     def _forward_event(self, event):
@@ -170,7 +175,11 @@ class MessageForwardingWorker(ApplicationWorker):
 
     def _get_event_url(self, event):
         msg_id = event['user_message_id']
-        return self.outbounds.load_event_url(self.channel_id, msg_id)
+        if msg_id is not None:
+            return self.outbounds.load_event_url(self.channel_id, msg_id)
+        else:
+            logging.warning(
+                "Cannot find event URL, missing user_message_id: %r" % event)
 
 
 class ChannelStatusConfig(BaseConfig):


### PR DESCRIPTION
Currently, if Junebug gets sent an event by the transport, but the `user_message_id` of the event is `null`, the event processing crashes and gets stuck. We should just log that the event doesn't have a message id, don't store it, and carry on.