### PR TITLE
Change SmppTransport to SmppTransceiverTransport

### DIFF
--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -45,7 +45,7 @@ class MessageTooLong(JunebugError):
 transports = {
     'telnet': 'vumi.transports.telnet.TelnetServerTransport',
     'xmpp': 'vumi.transports.xmpp.XMPPTransport',
-    'smpp': 'vumi.transports.smpp.SmppTransport',
+    'smpp': 'vumi.transports.smpp.SmppTransceiverTransport',
     'dmark': 'vumi.transports.dmark.DmarkUssdTransport',
 }
 


### PR DESCRIPTION
In vumi, the SmppTransport is actually the depreciated SmppTransceiverTransportWithOldConfig. We should change this over to the new SmppTransceiverTransport.