### PR TITLE
Updating channels to unset status_url, etc.

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -175,7 +175,7 @@ class JunebugApi(object):
                 'config': {'type': 'object'},
                 'metadata': {'type': 'object'},
                 'status_url': {'type': 'string'},
-                'mo_url': {'type': 'string'},
+                'mo_url': {'type': ['string', 'null']},
                 'rate_limit_count': {
                     'type': 'integer',
                     'minimum': 0,

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -331,6 +331,28 @@ class TestJunebugApi(JunebugTestBase):
             }))
 
     @inlineCallbacks
+    def test_modify_channel_config_remove_mo_url(self):
+        redis = yield self.get_redis()
+        properties = self.create_channel_properties()
+        config = yield self.create_channel_config()
+
+        channel = Channel(redis, config, properties, id='test-channel')
+        yield channel.save()
+        yield channel.start(self.service)
+
+        print properties
+
+        properties['config']['name'] = 'bar'
+        properties['mo_url'] = None
+        resp = yield self.post('/channels/test-channel', properties)
+
+        yield self.assert_response(
+            resp, http.OK, 'channel updated', conjoin(properties, {
+                'status': self.generate_status(),
+                'id': 'test-channel',
+            }))
+
+    @inlineCallbacks
     def test_modify_channel_invalid_parameters(self):
         resp = yield self.post('/channels/foo-bar', {
             'rate_limit_count': -3,


### PR DESCRIPTION
Currently one isn't allowed to post values for status_url that are `null` when updating a channel, which means there is no way to unset a status URL. We probably need to relax the validation on status_url and a few other fields to allow them to be null in addition to strings, so, e.g.:

``` python
"status_url": {"type": ["string", "null"]},
```
