### PR TITLE
Add timeout for HTTP requests

### DIFF
--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -4,9 +4,11 @@ import logging
 import logging.handlers
 
 from twisted.python.logfile import LogFile
+from twisted.python.failure import Failure
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue, succeed
 from twisted.internet.task import Clock
+from twisted.internet.error import ConnectionDone
 from twisted.trial.unittest import TestCase
 from twisted.web.server import Site
 
@@ -118,6 +120,10 @@ class RequestLoggingApi(object):
             })
         request.setResponseCode(500)
         return 'test-error-response'
+
+    @app.route('/implode/')
+    def imploding_request(self, request):
+        request.transport.connectionLost(reason=Failure(ConnectionDone()))
 
 
 class LoggingTestTransport(Transport):

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -109,6 +109,22 @@ class TestMessageForwardingWorker(JunebugTestBase):
         self.assert_was_logged('test-error-response')
 
     @inlineCallbacks
+    def test_send_message_imploding_response(self):
+        '''If there is an error connecting to the configured URL, the
+        error and message should be logged'''
+        self.patch_logger()
+        self.worker = yield self.get_worker({
+            'transport_name': 'testtransport',
+            'mo_message_url': self.url + '/implode/',
+            })
+        msg = TransportUserMessage.send(to_addr='+1234', content='testcontent')
+        yield self.worker.consume_user_message(msg)
+
+        self.assert_was_logged('Post to %s/implode/ failed because of' % (
+            self.url,))
+        self.assert_was_logged('ConnectionDone')
+
+    @inlineCallbacks
     def test_send_message_storing(self):
         '''Inbound messages should be stored in the InboundMessageStore'''
         msg = TransportUserMessage.send(to_addr='+1234', content='testcontent')


### PR DESCRIPTION
Currently, we will wait forever for an outbound HTTP request (from us to another service) to return. We should add a configurable timeout, with a sensible default value. `treq` provides a `timeout` parameter for us to do this.