### PR TITLE
Installing Junebug on py3 fails because of tiny setup.py bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='http://github.com/praekelt/junebug',
     license='BSD',
     description=(
-        'A system for managing text messaging transports via a RESTful HTTP ',
+        'A system for managing text messaging transports via a RESTful HTTP '
         'interface'),
     long_description=read_file('README.rst'),
     author='Praekelt Foundation',


### PR DESCRIPTION
The description is a tuple, for some reason this is not a problem in 
py2 but in py3 it is.