### PR TITLE
Allow auth on mo_url

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -122,6 +122,7 @@ class JunebugApi(object):
                 'metadata': {'type': 'object'},
                 'status_url': {'type': 'string'},
                 'mo_url': {'type': 'string'},
+                'mo_url_auth_token': {'type': 'string'},
                 'amqp_queue': {'type': 'string'},
                 'rate_limit_count': {
                     'type': 'integer',

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -290,6 +290,8 @@ class Channel(object):
         return {
             'transport_name': self.id,
             'mo_message_url': self._properties.get('mo_url'),
+            'mo_message_url_auth_token': self._properties.get(
+                'mo_url_auth_token'),
             'message_queue': self._properties.get('amqp_queue'),
             'redis_manager': self.config.redis,
             'inbound_ttl': self.config.inbound_message_ttl,

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -121,6 +121,15 @@ class RequestLoggingApi(object):
         request.setResponseCode(500)
         return 'test-error-response'
 
+    @app.route('/auth/')
+    def auth_token(self, request):
+        headers = request.requestHeaders
+        self.requests.append({
+            'Authorization': headers.getRawHeaders('Authorization'),
+        })
+        request.setResponseCode(200)
+        return 'auth-response'
+
     @app.route('/implode/')
     def imploding_request(self, request):
         request.transport.connectionLost(reason=Failure(ConnectionDone()))

--- a/junebug/tests/test_channel.py
+++ b/junebug/tests/test_channel.py
@@ -168,6 +168,7 @@ class TestChannel(JunebugTestBase):
         self.assertEqual(worker.config, {
             'transport_name': channel.id,
             'mo_message_url': 'http://foo.org',
+            'mo_message_url_auth_token': None,
             'message_queue': None,
             'redis_manager': channel.config.redis,
             'inbound_ttl': channel.config.inbound_message_ttl,

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -100,7 +100,6 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         # Inject the auth parameters
         url = self.url.replace('http://', 'http://foo:bar@') + '/auth/'
-        print 'url', url
 
         self.worker = yield self.get_worker({
             'transport_name': 'testtransport',

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -1,4 +1,5 @@
 import treq
+from base64 import b64encode
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
@@ -90,6 +91,47 @@ class TestMessageForwardingWorker(JunebugTestBase):
             'testqueue', 'inbound', TransportUserMessage)
 
         self.assertEqual(dispatched_msg, msg)
+
+    @inlineCallbacks
+    def test_send_message_with_basic_auth(self):
+        '''If there is an error sending a message to the configured URL, the
+        error and message should be logged'''
+        self.patch_logger()
+
+        # Inject the auth parameters
+        url = self.url.replace('http://', 'http://foo:bar@') + '/auth/'
+        print 'url', url
+
+        self.worker = yield self.get_worker({
+            'transport_name': 'testtransport',
+            'mo_message_url': url,
+        })
+        msg = TransportUserMessage.send(to_addr='+1234', content='testcontent')
+        yield self.worker.consume_user_message(msg)
+
+        [logged_request] = self.logging_api.requests
+        self.assertEqual(logged_request, {
+            'Authorization': ['Basic %s' % (b64encode('foo:bar'),)]
+        })
+
+    @inlineCallbacks
+    def test_send_message_with_token_auth(self):
+        '''If there is an error sending a message to the configured URL, the
+        error and message should be logged'''
+        self.patch_logger()
+
+        self.worker = yield self.get_worker({
+            'transport_name': 'testtransport',
+            'mo_message_url': self.url + '/auth/',
+            'mo_message_url_auth_token': 'the-auth-token'
+        })
+        msg = TransportUserMessage.send(to_addr='+1234', content='testcontent')
+        yield self.worker.consume_user_message(msg)
+
+        [logged_request] = self.logging_api.requests
+        self.assertEqual(logged_request, {
+            'Authorization': ['Token the-auth-token']
+        })
 
     @inlineCallbacks
     def test_send_message_bad_response(self):

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from urlparse import urlunparse
 
 import treq
 
@@ -10,7 +11,8 @@ from twisted.internet.error import (
 from twisted.internet.task import TaskStopped
 
 from vumi.application.base import ApplicationConfig, ApplicationWorker
-from vumi.config import ConfigDict, ConfigInt, ConfigText, ConfigFloat
+from vumi.config import (
+    ConfigDict, ConfigInt, ConfigText, ConfigFloat, ConfigUrl)
 from vumi.message import JSONMessageEncoder
 from vumi.persist.txredis_manager import TxRedisManager
 from vumi.worker import BaseConfig, BaseWorker
@@ -23,8 +25,12 @@ from junebug.stores import (
 class MessageForwardingConfig(ApplicationConfig):
     '''Config for MessageForwardingWorker application worker'''
 
-    mo_message_url = ConfigText(
+    mo_message_url = ConfigUrl(
         "The URL to send HTTP POST requests to for MO messages",
+        default=None, static=True)
+
+    mo_message_url_auth_token = ConfigText(
+        "Authorization Token to use for the mo_message_url",
         default=None, static=True)
 
     mo_message_url_timeout = ConfigInt(
@@ -101,8 +107,41 @@ class MessageForwardingWorker(ApplicationWorker):
 
         if self.config.get('mo_message_url') is not None:
             config = self.get_static_config()
-            resp = yield post(config.mo_message_url, msg,
-                              timeout=config.mo_message_url_timeout)
+
+            # Parse the basic auth username & password if available
+            username = config.mo_message_url.username
+            password = config.mo_message_url.password
+            if any([username, password]):
+                url = urlunparse((
+                    config.mo_message_url.scheme,
+                    '%s%s' % (
+                        config.mo_message_url.hostname,
+                        (':%s' % (config.mo_message_url.port,)
+                         if config.mo_message_url.port is not None
+                         else '')),
+                    config.mo_message_url.path,
+                    config.mo_message_url.params,
+                    config.mo_message_url.query,
+                    config.mo_message_url.fragment,
+                ))
+                auth = (username, password)
+            else:
+                url = config.mo_message_url.geturl()
+                auth = None
+
+            # Construct token auth headers if configured
+            auth_token = config.mo_message_url_auth_token
+            if auth_token:
+                headers = {
+                    'Authorization': [
+                        'Token %s' % (auth_token,)]
+                }
+            else:
+                headers = {}
+
+            resp = yield post(url, msg,
+                              timeout=config.mo_message_url_timeout,
+                              auth=auth, headers=headers)
             if resp and request_failed(resp):
                 logging.exception(
                     'Error sending message, received HTTP code %r with body %r'
@@ -281,11 +320,13 @@ def post_eb(reason, url):
         url, err_class, reason.getErrorMessage()))
 
 
-def post(url, data, timeout):
+def post(url, data, timeout, auth=None, headers={}):
+    request_headers = {'Content-Type': ['application/json']}
+    request_headers.update(headers)
     d = treq.post(
         url.encode('utf-8'),
         data=json.dumps(data, cls=JSONMessageEncoder),
-        headers={'Content-Type': 'application/json'},
-        timeout=timeout)
+        headers=request_headers,
+        timeout=timeout, auth=auth)
     d.addErrback(post_eb, url)
     return d


### PR DESCRIPTION
Auth can either be basic auth:

```mo_url: 'https://foo:bar@example.org/'```

or via token auth:

```mo_url_auth_token: 'the token to use'```