### PR TITLE
Trap RequestTransmissionFailed

### DIFF
--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -5,8 +5,7 @@ from urlparse import urlunparse, urlparse
 import treq
 
 from twisted.internet.defer import inlineCallbacks, CancelledError
-from twisted.web.client import ResponseFailed
-from twisted.web._newclient import RequestTransmissionFailed
+from twisted.web.client import ResponseFailed, RequestTransmissionFailed
 from twisted.internet.error import (
     ConnectingCancelledError, ConnectionDone, ConnectionRefusedError)
 from twisted.internet.task import TaskStopped

--- a/junebug/workers.py
+++ b/junebug/workers.py
@@ -6,6 +6,7 @@ import treq
 
 from twisted.internet.defer import inlineCallbacks, CancelledError
 from twisted.web.client import ResponseFailed
+from twisted.web._newclient import RequestTransmissionFailed
 from twisted.internet.error import (
     ConnectingCancelledError, ConnectionDone, ConnectionRefusedError)
 from twisted.internet.task import TaskStopped
@@ -337,7 +338,9 @@ def post_eb(reason, url):
         TaskStopped,
         # Raised when Deferred is cancelled because of timeouts
         CancelledError,
+        RequestTransmissionFailed,
     )
+
     err_class = reason.trap(*errors)
     logging.exception('Post to %s failed because of %s: %s' % (
         url, err_class, reason.getErrorMessage()))


### PR DESCRIPTION
This exception is killing the channel:
`RequestTransmissionFailed: [<twisted.python.failure.Failure twisted.internet.error.ConnectionDone: Connection was closed cleanly.>]`

`RequestTransmissionFailed` is a wrapper exception which contains `ConnectionDone` which we are trying to trap.