### PR TITLE
Fix Junebug readthedocs documentation build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ sys.path.append(os.path.abspath('.'))
 # ones.
 extensions = [
     'sphinx.ext.todo',
-    'sphinxarg.ext',
+    'sphinx_argparse.ext',
     'sphinx_confmodel.ext',
     'sphinxcontrib.httpdomain',
     'sphinx.ext.autodoc',

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -102,14 +102,14 @@ If we take a look at our requestbin url, we should see a new request:
   .. code-block:: json
 
     {
-        channel_data: {session_event: "resume"},
-        from: "127.0.0.1:53378",
-        channel_id: "bc5f2e63-7f53-4996-816d-4f89f45a5842",
-        timestamp: "2015-10-06 14:30:51.876897",
-        content: "hi there",
-        to: "0.0.0.0:9001",
-        reply_to: null,
-        message_id: "22c9cd74c5ff42d9b8e1a538e2a17175"
+        "channel_data": {"session_event": "resume"},
+        "from": "127.0.0.1:53378",
+        "channel_id": "bc5f2e63-7f53-4996-816d-4f89f45a5842",
+        "timestamp": "2015-10-06 14:30:51.876897",
+        "content": "hi there",
+        "to": "0.0.0.0:9001",
+        "reply_to": null,
+        "message_id": "22c9cd74c5ff42d9b8e1a538e2a17175"
     }
 
 Now, lets send a reply to this message by referencing its `message_id`::

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,4 +1,4 @@
-.. _release-notes
+.. _release-notes:
 
 Release Notes
 =============

--- a/docs/sphinx_argparse/ext.py
+++ b/docs/sphinx_argparse/ext.py
@@ -1,0 +1,79 @@
+from docutils.nodes import (
+    paragraph,
+    literal_block, title, description,
+    option, option_list, option_list_item, option_group, option_string)
+from docutils.parsers.rst.directives import unchanged
+
+from sphinx.util.compat import Directive
+
+from argparse import _HelpAction
+
+
+class ArgParseDirection(Directive):
+    """
+    This is a generator that implements just the small subset of features that
+    we need from sphinx-argparse, since sphinx-argparse currently does not work
+    with readthedocs.
+    """
+    has_content = True
+
+    option_spec = {
+        'module': unchanged,
+        'func': unchanged,
+        'prog': unchanged,
+    }
+
+    def run(self):
+        args = load_function(self.options['module'], self.options['func'])()
+        args.prog = self.options['prog']
+
+        return [
+            el(paragraph, text=args.description),
+            el(literal_block, text=args.format_usage()),
+            el(title, text='Named Arguments'),
+            el(option_list, [
+                el(option_list_item, [
+                    el(option_group, [
+                        el(option, [
+                            el(option_string, text=arg),
+                        ])
+                        for arg in arguments
+                    ]),
+                    el(description, [
+                        el(paragraph, text=descrip),
+                    ])
+                ])
+                for descrip, arguments in get_options(args)
+            ]),
+        ]
+
+
+def get_options(parser):
+    # We unfortunately have to use private access here, as ArgParse doesn't
+    # give us direct access to the arguments, only a formatted string of all
+    # arguments. sphinx-argparse does the same thing.
+    action = parser._action_groups[1]  # optional arguments
+    options = []
+    for action in action._group_actions:
+        if isinstance(action, _HelpAction):
+            continue
+
+        help_string = action.help or None
+        options.append((help_string, action.option_strings))
+    return options
+
+
+def el(cls, children=None, **kw):
+    element = cls(**kw)
+    element += children if children is not None else []
+    return element
+
+
+def load_function(module_path, function_name):
+    return getattr(
+        __import__(module_path, fromlist=[function_name]),
+        function_name)
+
+
+def setup(app):
+    app.add_directive('argparse', ArgParseDirection)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,4 @@
 Sphinx>=1.2
-sphinx-argparse
 sphinxcontrib-httpdomain>=1.2.0
 sphinxcontrib-blockdiag>=1.5.4
 # txJSON-RPC 0.5 is a vumi requirement, but is not compatible with docutils 0.13


### PR DESCRIPTION
Currently, sphinx argparse is not working with readthedocs. There are some issues and PRs on the repo, but for now it seems like development has stalled.

This PR adds an argparse module for sphinx, which implements just the minimum functionality that we need to generate our CLI documentation, and removes the requirement on sphinx argparse.

Built documentation can be viewed at http://junebug.readthedocs.io/en/feature-momza-830-fix-junebug-documentation-build/