### PR TITLE
Change function from validate_config to validate_router_config

### DIFF
--- a/junebug/router/base.py
+++ b/junebug/router/base.py
@@ -108,7 +108,7 @@ class Router(object):
         """
         worker_class = load_class_by_string(self._worker_class_name)
         return maybeDeferred(
-            worker_class.validate_config, self._worker_config)
+            worker_class.validate_router_config, self._worker_config)
 
     def start(self, service):
         """

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -146,7 +146,7 @@ class TestRouter(BaseWorker):
     """Router used for testing the API."""
     # TODO: Create a proper base class for Junebug routers
     @classmethod
-    def validate_config(cls, config):
+    def validate_router_config(cls, config):
         """Testing config requires the ``test`` parameter to be ``pass``"""
         if config.get('test') != 'pass':
             raise InvalidRouterConfig('test must be pass')

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -151,6 +151,15 @@ class TestRouter(BaseWorker):
         if config.get('test') != 'pass':
             raise InvalidRouterConfig('test must be pass')
 
+    def setup_connectors(self):
+        pass
+
+    def setup_worker(self):
+        pass
+
+    def teardown_worker(self):
+        pass
+
 
 class JunebugTestBase(TestCase):
     '''Base test case that all junebug tests inherit from. Contains useful


### PR DESCRIPTION
The vumi base worker class already has a `validate_config` function, which gets called when the vumi worker gets started. We should rename our `validate_config` function so that there's not a clash.

Also, by default the `setup_connectors`, `setup_worker`, and `teardown_worker` functions raise a `NotImplementedError`. We should add dummy functions to the test router so that we can use the dummy router for testing.

The reason this isn't picked up in unit tests is that we don't actually start and stop the workers in the unit tests, as per https://github.com/praekelt/junebug/issues/50