### PR TITLE
Add handling for invalid json in body decoding

### DIFF
--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -41,6 +41,11 @@ class TestJunebugApi(JunebugTestBase):
             persistent=False,
             headers=headers)
 
+    def raw_post(self, url, body, headers=None):
+        return treq.post(
+            "{}{}".format(self.url, url), body, persistent=False,
+            headers=headers)
+
     def put(self, url, data, headers=None):
         return treq.put(
             "%s%s" % (self.url, url),
@@ -107,6 +112,20 @@ class TestJunebugApi(JunebugTestBase):
         yield self.assert_response(
             resp, http.OK,
             'channels listed', [])
+
+    @inlineCallbacks
+    def test_invalid_json_handling(self):
+        """
+        Invalid JSON in the body should result in a bad request error
+        """
+        resp = yield self.raw_post('/channels/', '{')
+        self.assert_response(
+            resp, http.BAD_REQUEST, 'json decode error', {
+                'errors': [{
+                    'message': 'Expecting object: line 1 column 1 (char 0)',
+                    'type': 'JsonDecodeError',
+                }]
+            })
 
     @inlineCallbacks
     def test_startup_plugins_started(self):

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -119,10 +119,16 @@ class TestJunebugApi(JunebugTestBase):
         Invalid JSON in the body should result in a bad request error
         """
         resp = yield self.raw_post('/channels/', '{')
+
+        try:
+            json.loads('{')
+        except ValueError as e:
+            msg = e.message
+
         self.assert_response(
             resp, http.BAD_REQUEST, 'json decode error', {
                 'errors': [{
-                    'message': 'Expecting object: line 1 column 1 (char 0)',
+                    'message': msg,
                     'type': 'JsonDecodeError',
                 }]
             })


### PR DESCRIPTION
Currently, if bad JSON is POSTed in the body of a request, we get an unhandled ValueError, and so a 500 server error is returned. This is not correct, as bad JSON in the body of the request is not a server error, it is a 400 bad request error, and so that should be returned instead.

This should also mean that incorrect JSON in the body won't be reported to sentry