### PR TITLE
Add a base class for router workers

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -336,7 +336,7 @@ class JunebugApi(object):
     @inlineCallbacks
     def create_router(self, request, body):
         """Create a new router"""
-        router = Router(self.router_store, self.config, body)
+        router = Router(self, body)
         yield router.validate_config()
         router.start(self.service)
         yield router.save()
@@ -350,8 +350,7 @@ class JunebugApi(object):
     @app.route('/routers/<string:router_id>', methods=['GET'])
     def get_router(self, request, router_id):
         """Get the configuration details and status of a specific router"""
-        d = Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        d = Router.from_id(self, router_id)
         d.addCallback(lambda router: router.status())
         d.addCallback(partial(response, request, 'router found'))
         return d
@@ -373,8 +372,7 @@ class JunebugApi(object):
     @inlineCallbacks
     def replace_router_config(self, request, body, router_id):
         """Replace the router config with the one specified"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
 
         for field in ['type', 'label', 'config', 'metadata']:
             router.router_config.pop(field, None)
@@ -405,8 +403,7 @@ class JunebugApi(object):
     @inlineCallbacks
     def update_router_config(self, request, body, router_id):
         """Update the router config with the one specified"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
 
         router.router_config.update(body)
         yield router.validate_config()
@@ -421,8 +418,7 @@ class JunebugApi(object):
     @app.route('/routers/<string:router_id>', methods=['DELETE'])
     @inlineCallbacks
     def delete_router(self, request, router_id):
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
         yield router.stop()
         yield router.delete()
         returnValue(response(request, 'router deleted', {}))
@@ -450,8 +446,7 @@ class JunebugApi(object):
     @inlineCallbacks
     def create_router_destination(self, request, body, router_id):
         """Create a new destination for the router"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
         yield router.validate_destination_config(body['config'])
 
         destination = router.add_destination(body)
@@ -467,8 +462,7 @@ class JunebugApi(object):
     @app.route('/routers/<string:router_id>/destinations/', methods=['GET'])
     def get_router_destination_list(self, request, router_id):
         """Get the list of destinations for a router"""
-        d = Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        d = Router.from_id(self, router_id)
         d.addCallback(lambda router: router.get_destination_list())
         d.addCallback(partial(response, request, 'destinations retrieved'))
         return d
@@ -479,8 +473,7 @@ class JunebugApi(object):
     @inlineCallbacks
     def get_destination(self, request, router_id, destination_id):
         """Get the config and status of a destination"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
         destination = router.get_destination(destination_id)
         returnValue(response(
             request, 'destination found', (yield destination.status())
@@ -512,8 +505,7 @@ class JunebugApi(object):
     def replace_router_destination(
             self, request, body, router_id, destination_id):
         """Replace the config of a router destination"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
         yield router.validate_destination_config(body['config'])
 
         destination = router.get_destination(destination_id)
@@ -553,8 +545,7 @@ class JunebugApi(object):
     def update_router_destination(
             self, request, body, router_id, destination_id):
         """Update the config of a router destination"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
         if 'config' in body:
             yield router.validate_destination_config(body['config'])
 
@@ -574,8 +565,7 @@ class JunebugApi(object):
     @inlineCallbacks
     def delete_router_destination(self, request, router_id, destination_id):
         """Delete and stop the router destination"""
-        router = yield Router.from_id(
-            self.router_store, self.config, self.service, router_id)
+        router = yield Router.from_id(self, router_id)
         destination = router.get_destination(destination_id)
 
         yield router.stop()

--- a/junebug/channel.py
+++ b/junebug/channel.py
@@ -422,7 +422,12 @@ class Channel(object):
 
     def _restore(self, service):
         self.transport_worker = service.getServiceNamed(self.id)
-        self.application_worker = service.getServiceNamed(self.application_id)
+        try:
+            self.application_worker = service.getServiceNamed(
+                self.application_id)
+        except KeyError:
+            # Doesn't have an application worker if no destination specified
+            pass
         self.status_application_worker = service.getServiceNamed(
             self.status_application_id)
 

--- a/junebug/router/__init__.py
+++ b/junebug/router/__init__.py
@@ -1,8 +1,10 @@
 from .base import (
-    Router, InvalidRouterConfig, InvalidRouterDestinationConfig, RouterNotFound
+    Router, InvalidRouterConfig, InvalidRouterDestinationConfig,
+    RouterNotFound, BaseRouterWorker
 )
 
 Router
 InvalidRouterConfig
 InvalidRouterDestinationConfig
 RouterNotFound
+BaseRouterWorker

--- a/junebug/router/from_address.py
+++ b/junebug/router/from_address.py
@@ -3,14 +3,12 @@ from confmodel.config import ConfigField
 from confmodel.errors import ConfigError
 from confmodel.fields import ConfigBool
 import re
-from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue
+from twisted.internet.defer import gatherResults, inlineCallbacks
 from uuid import UUID
-from vumi.persist.txredis_manager import TxRedisManager
 
 from junebug.channel import Channel, ChannelNotFound
 from junebug.router import (
     BaseRouterWorker, InvalidRouterConfig, InvalidRouterDestinationConfig)
-from junebug.stores import OutboundMessageStore
 
 
 class ConfigUUID(ConfigField):

--- a/junebug/router/from_address.py
+++ b/junebug/router/from_address.py
@@ -1,0 +1,109 @@
+from confmodel import Config
+from confmodel.config import ConfigField
+from confmodel.errors import ConfigError
+from confmodel.fields import ConfigBool
+import re
+from uuid import UUID
+
+from junebug.channel import Channel
+from junebug.router import (
+    BaseRouterWorker, InvalidRouterConfig, InvalidRouterDestinationConfig)
+
+
+class ConfigUUID(ConfigField):
+    """
+    Field for validating UUIDs
+    """
+    field_type = 'uuid'
+
+    def clean(self, value):
+        try:
+            return UUID(value)
+        except (ValueError, AttributeError, TypeError):
+            self.raise_config_error('is not a valid UUID')
+
+
+class ConfigRegularExpression(ConfigField):
+    """
+    Field for validation regular expressions
+    """
+    field_type = 'regex'
+
+    def clean(self, value):
+        try:
+            return re.compile(value)
+        except (ValueError, TypeError, re.error) as e:
+            self.raise_config_error(
+                'is not a valid regular expression: {}'.format(e.message))
+
+
+class FromAddressRouterConfig(BaseRouterWorker.CONFIG_CLASS):
+    """
+    Config for the FromAddressRouter.
+    """
+    channel = ConfigUUID(
+        "The UUID of the channel to route messages for. This channel may not "
+        "have an ``amqp_queue`` or ``mo_url`` parameter specified.",
+        required=True, static=True)
+
+
+class FromAddressRouterDestinationConfig(Config):
+    """
+    Config for each destination of the FromAddressRouter.
+    """
+    regular_expression = ConfigRegularExpression(
+        "The regular expression to match the from address on for this "
+        "destination. Any inbound messages with a from address that matches "
+        "this regular expression will be sent to this destination.",
+        required=True, static=True)
+    default = ConfigBool(
+        "Whether or not this destination is a default destination. Any "
+        "messages that don't match any the destination regular expressions "
+        "will be sent to the default destination(s).",
+        required=False, default=False, static=True)
+
+
+class FromAddressRouter(BaseRouterWorker):
+    """
+    A router that routes inbound messages based on the from address of the
+    message
+    """
+    CONFIG_CLASS = FromAddressRouterConfig
+    DESTINATION_CONFIG_CLASS = FromAddressRouterDestinationConfig
+
+    @classmethod
+    def validate_router_config(cls, api, config):
+        try:
+            config = cls.CONFIG_CLASS(config)
+        except ConfigError as e:
+            raise InvalidRouterConfig(e.message)
+
+        channel_id = str(config.channel)
+        d = Channel.from_id(
+            api.redis, api.config, channel_id, api.service, api.plugins)
+
+        def handle_missing_channel(err):
+            raise InvalidRouterConfig(
+                "Channel {} does not exist".format(channel_id))
+
+        def ensure_valid_channel(channel):
+            if channel.has_destination:
+                raise InvalidRouterConfig(
+                    "Channel {} already has a destination specified".format(
+                        channel_id))
+
+        d.addErrback(handle_missing_channel)
+        return d.addCallback(ensure_valid_channel)
+
+    @classmethod
+    def validate_router_destination_config(cls, api, config):
+        try:
+            cls.DESTINATION_CONFIG_CLASS(config)
+        except ConfigError as e:
+            raise InvalidRouterDestinationConfig(e.message)
+
+    def setup_router(self):
+        pass
+
+    def teardown_router(self):
+        pass

--- a/junebug/stores.py
+++ b/junebug/stores.py
@@ -3,7 +3,8 @@ from math import ceil
 import time
 from twisted.internet.defer import inlineCallbacks, returnValue, gatherResults
 
-from vumi.message import TransportEvent, TransportUserMessage, TransportStatus
+from vumi.message import (
+    TransportEvent, TransportUserMessage, TransportStatus, to_json, from_json)
 
 
 class BaseStore(object):
@@ -118,32 +119,35 @@ class InboundMessageStore(BaseStore):
 class OutboundMessageStore(BaseStore):
     '''Stores the event url, in order to look it up when deciding where events
     should go'''
-    PROPERTY_KEYS = ['event_url', 'event_url_auth_token']
+    PROPERTY_KEYS = ['message']
 
     def get_key(self, channel_id, message_id):
         return super(OutboundMessageStore, self).get_key(
             channel_id, 'outbound_messages', message_id)
 
-    def store_event_url(self, channel_id, message_id, event_url):
-        '''Stores the event_url'''
-        key = self.get_key(channel_id, message_id)
-        return self.store_property(key, 'event_url', event_url)
-
-    def store_event_auth_token(self, channel_id, message_id, auth_token):
-        '''Stores the event_auth_token'''
-        key = self.get_key(channel_id, message_id)
-        return self.store_property(key, 'event_url_auth_token', auth_token)
-
     def load_event_url(self, channel_id, message_id):
         '''Retrieves a stored event url, given the channel and message ids'''
         key = self.get_key(channel_id, message_id)
-        return self.load_property(key, 'event_url')
+        d = self.load_property(key, 'message')
+        d.addCallback(from_json)
+        d.addErrback(lambda _: {})
+        d.addCallback(lambda m: m.get('event_url', None))
+        return d
 
     def load_event_auth_token(self, channel_id, message_id):
         '''Retrieves a stored event auth token, given the channel and message
         ids'''
         key = self.get_key(channel_id, message_id)
-        return self.load_property(key, 'event_url_auth_token')
+        d = self.load_property(key, 'message')
+        d.addCallback(from_json)
+        d.addErrback(lambda _: {})
+        d.addCallback(lambda m: m.get('event_auth_token', None))
+        return d
+
+    def store_message(self, channel_id, message):
+        '''Stores an outbound message'''
+        key = self.get_key(channel_id, message['message_id'])
+        return self.store_property(key, 'message', to_json(message))
 
     def store_event(self, channel_id, message_id, event):
         '''Stores an event for a message'''

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -144,6 +144,9 @@ class LoggingTestTransport(Transport):
 
 class TestRouter(BaseRouterWorker):
     """Router used for testing the API."""
+    setup_called = False
+    teardown_called = False
+
     @classmethod
     def validate_router_config(cls, api, config):
         """Testing config requires the ``test`` parameter to be ``pass``"""
@@ -156,6 +159,12 @@ class TestRouter(BaseRouterWorker):
         ``valid``"""
         if config.get('target') != 'valid':
             raise InvalidRouterDestinationConfig('target must be valid')
+
+    def setup_router(self):
+        self.setup_called = True
+
+    def teardown_router(self):
+        self.teardown_called = True
 
 
 class JunebugTestBase(TestCase):

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -146,13 +146,13 @@ class TestRouter(BaseWorker):
     """Router used for testing the API."""
     # TODO: Create a proper base class for Junebug routers
     @classmethod
-    def validate_router_config(cls, config):
+    def validate_router_config(cls, api, config):
         """Testing config requires the ``test`` parameter to be ``pass``"""
         if config.get('test') != 'pass':
             raise InvalidRouterConfig('test must be pass')
 
     @classmethod
-    def validate_destination_config(cls, config):
+    def validate_destination_config(cls, api, config):
         """Testing destination config requires the ``target`` parameter to be
         ``valid``"""
         if config.get('target') != 'valid':

--- a/junebug/tests/helpers.py
+++ b/junebug/tests/helpers.py
@@ -20,14 +20,14 @@ from vumi.service import get_spec
 from vumi.tests.fake_amqp import FakeAMQPBroker, FakeAMQPChannel
 from vumi.tests.helpers import PersistenceHelper
 from vumi.transports import Transport
-from vumi.worker import BaseWorker
 
 import junebug
 from junebug import JunebugApi
 from junebug.amqp import JunebugAMQClient, MessageSender
 from junebug.channel import Channel
 from junebug.plugin import JunebugPlugin
-from junebug.router import InvalidRouterConfig, InvalidRouterDestinationConfig
+from junebug.router import (
+    InvalidRouterConfig, InvalidRouterDestinationConfig, BaseRouterWorker)
 from junebug.service import JunebugService
 from junebug.config import JunebugConfig
 from junebug.stores import MessageRateStore
@@ -142,9 +142,8 @@ class LoggingTestTransport(Transport):
         self.log.msg(message, source=self)
 
 
-class TestRouter(BaseWorker):
+class TestRouter(BaseRouterWorker):
     """Router used for testing the API."""
-    # TODO: Create a proper base class for Junebug routers
     @classmethod
     def validate_router_config(cls, api, config):
         """Testing config requires the ``test`` parameter to be ``pass``"""
@@ -157,15 +156,6 @@ class TestRouter(BaseWorker):
         ``valid``"""
         if config.get('target') != 'valid':
             raise InvalidRouterDestinationConfig('target must be valid')
-
-    def setup_connectors(self):
-        pass
-
-    def setup_worker(self):
-        pass
-
-    def teardown_worker(self):
-        pass
 
 
 class JunebugTestBase(TestCase):

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -1264,8 +1264,8 @@ class TestJunebugApi(JunebugTestBase):
         self.assertEqual(transport.parent, self.service)
 
         worker_config = config['config']
-        worker_config['destinations'] = []
-        self.assertEqual(transport.config, worker_config)
+        for k, v in worker_config.items():
+            self.assertEqual(transport.config[k], worker_config[k])
 
     @inlineCallbacks
     def test_create_router_saves_config(self):
@@ -1316,8 +1316,8 @@ class TestJunebugApi(JunebugTestBase):
         self.assertEqual(router_config, old_config)
         router_worker = self.api.service.namedServices[router_id]
         router_worker_config = old_config['config']
-        router_worker_config['destinations'] = []
-        self.assertEqual(router_worker.config, router_worker_config)
+        for k, v in router_worker_config.items():
+            self.assertEqual(router_worker.config[k], router_worker_config[k])
 
         new_config = self.create_router_config(config={'test': 'pass'})
         new_config.pop('label', None)
@@ -1332,8 +1332,8 @@ class TestJunebugApi(JunebugTestBase):
         self.assertEqual(router_config, new_config)
         router_worker = self.api.service.namedServices[router_id]
         router_worker_config = new_config['config']
-        router_worker_config['destinations'] = []
-        self.assertEqual(router_worker.config, router_worker_config)
+        for k, v in router_worker_config.items():
+            self.assertEqual(router_worker.config[k], router_worker_config[k])
 
         router_worker = self.api.service.namedServices[router_id]
 
@@ -1375,8 +1375,8 @@ class TestJunebugApi(JunebugTestBase):
         self.assertEqual(router_config, old_config)
         router_worker = self.api.service.namedServices[router_id]
         router_worker_config = old_config['config']
-        router_worker_config['destinations'] = []
-        self.assertEqual(router_worker.config, router_worker_config)
+        for k, v in router_worker_config.items():
+            self.assertEqual(router_worker.config[k], router_worker_config[k])
 
         update = {'config': {'test': 'pass', 'new': 'new'}}
         new_config = deepcopy(old_config)
@@ -1393,8 +1393,8 @@ class TestJunebugApi(JunebugTestBase):
         self.assertEqual(router_config, new_config)
         router_worker = self.api.service.namedServices[router_id]
         router_worker_config = new_config['config']
-        router_worker_config['destinations'] = []
-        self.assertEqual(router_worker.config, new_config['config'])
+        for k, v in router_worker_config.items():
+            self.assertEqual(router_worker.config[k], router_worker_config[k])
 
         router_worker = self.api.service.namedServices[router_id]
 

--- a/junebug/tests/test_from_address_router.py
+++ b/junebug/tests/test_from_address_router.py
@@ -1,0 +1,86 @@
+from twisted.internet.defer import inlineCallbacks
+import uuid
+
+from junebug.router import InvalidRouterConfig, InvalidRouterDestinationConfig
+from junebug.router.from_address import FromAddressRouter
+from junebug.tests.helpers import JunebugTestBase
+
+
+class TestRouter(JunebugTestBase):
+    def setUp(self):
+        return self.start_server()
+
+    @inlineCallbacks
+    def test_validate_router_config_invalid_channel_uuid(self):
+        """
+        If the provided channel UUID is not a valid UUID a config error should
+        be raised
+        """
+        with self.assertRaises(InvalidRouterConfig) as e:
+            yield FromAddressRouter.validate_router_config(
+                self.api, {'channel': "bad-uuid"})
+
+        self.assertEqual(
+            e.exception.message,
+            "Field 'channel' is not a valid UUID")
+
+    @inlineCallbacks
+    def test_validate_router_config_missing_channel(self):
+        """
+        If the provided channel UUID is not for an existing channel, a config
+        error should be raised
+        """
+        channel_id = str(uuid.uuid4())
+
+        with self.assertRaises(InvalidRouterConfig) as e:
+            yield FromAddressRouter.validate_router_config(
+                self.api, {'channel': channel_id})
+
+        self.assertEqual(
+            e.exception.message,
+            "Channel {} does not exist".format(channel_id))
+
+    @inlineCallbacks
+    def test_validate_router_config_existing_destination(self):
+        """
+        If the specified channel already has a destination specified, then
+        a config error should be raised
+        """
+        channel = yield self.create_channel(self.api.service, self.redis)
+
+        with self.assertRaises(InvalidRouterConfig) as e:
+            yield FromAddressRouter.validate_router_config(
+                self.api, {'channel': channel.id})
+
+        self.assertEqual(
+            e.exception.message,
+            "Channel {} already has a destination specified".format(
+                channel.id))
+
+    @inlineCallbacks
+    def test_validate_router_destination_config_invalid_regex(self):
+        """
+        If invalid regex is passed into the regex field, a config error should
+        be raised
+        """
+        with self.assertRaises(InvalidRouterDestinationConfig) as e:
+            yield FromAddressRouter.validate_router_destination_config(
+                self.api, {'regular_expression': "("})
+
+        self.assertEqual(
+            e.exception.message,
+            "Field 'regular_expression' is not a valid regular expression: "
+            "unbalanced parenthesis")
+
+    @inlineCallbacks
+    def test_validate_router_destination_config_missing_field(self):
+        """
+        regular_expression should be a required field
+        """
+        with self.assertRaises(InvalidRouterDestinationConfig) as e:
+            yield FromAddressRouter.validate_router_destination_config(
+                self.api, {})
+
+        self.assertEqual(
+            e.exception.message,
+            "Missing required config field 'regular_expression'")

--- a/junebug/tests/test_stores.py
+++ b/junebug/tests/test_stores.py
@@ -1,11 +1,13 @@
 import json
 from twisted.internet.defer import inlineCallbacks, returnValue
-from vumi.message import TransportEvent, TransportUserMessage, TransportStatus
+from vumi.message import (
+    TransportEvent, TransportUserMessage, TransportStatus, to_json)
 
 from junebug.stores import (
     BaseStore, InboundMessageStore, OutboundMessageStore, StatusStore,
     MessageRateStore, RouterStore)
 from junebug.tests.helpers import JunebugTestBase
+from junebug.utils import api_from_message
 
 
 class TestBaseStore(JunebugTestBase):
@@ -270,33 +272,13 @@ class TestOutboundMessageStore(JunebugTestBase):
         returnValue(store)
 
     @inlineCallbacks
-    def test_store_event_url(self):
-        '''Stores the event URL under the message ID'''
-        store = yield self.create_store()
-        yield store.store_event_url(
-            'channel_id', 'messageid', 'http://test.org')
-        event_url = yield self.redis.hget(
-            'channel_id:outbound_messages:messageid', 'event_url')
-        self.assertEqual(event_url, 'http://test.org')
-
-    @inlineCallbacks
-    def test_store_event_auth_token(self):
-        '''Stores the event auth token under the message ID'''
-        store = yield self.create_store()
-        yield store.store_event_auth_token(
-            'channel_id', 'messageid', "the-auth-token")
-        event_auth_token = yield self.redis.hget(
-            'channel_id:outbound_messages:messageid', 'event_url_auth_token')
-        self.assertEqual(event_auth_token, "the-auth-token")
-
-    @inlineCallbacks
     def test_load_event_url(self):
         '''Returns a vumi message from the stored json'''
         store = yield self.create_store()
         vumi_msg = TransportUserMessage.send(to_addr='+213', content='foo')
-        yield self.redis.hset(
-            'channel_id:outbound_messages:%s' % vumi_msg.get('message_id'),
-            'event_url', 'http://test.org')
+        msg = {'event_url': "http://test.org"}
+        msg.update(api_from_message(vumi_msg))
+        yield store.store_message('channel_id', msg)
 
         event_url = yield store.load_event_url(
             'channel_id', vumi_msg.get('message_id'))
@@ -307,9 +289,9 @@ class TestOutboundMessageStore(JunebugTestBase):
         '''Returns the event auth token under the message ID'''
         store = yield self.create_store()
         vumi_msg = TransportUserMessage.send(to_addr='+213', content='foo')
-        yield self.redis.hset(
-            'channel_id:outbound_messages:%s' % vumi_msg.get('message_id'),
-            'event_url_auth_token', "the-auth-token")
+        msg = {'event_auth_token': 'the-auth-token'}
+        msg.update(api_from_message(vumi_msg))
+        yield store.store_message('channel_id', msg)
 
         event_auth_token = yield store.load_event_auth_token(
             'channel_id', vumi_msg.get('message_id'))
@@ -328,6 +310,18 @@ class TestOutboundMessageStore(JunebugTestBase):
         store = yield self.create_store()
         self.assertEqual((yield store.load_event_auth_token(
             'bad-channel', 'bad-id')), None)
+
+    @inlineCallbacks
+    def test_store_message(self):
+        '''Stores the message under the correct key'''
+        store = yield self.create_store()
+        msg = TransportUserMessage.send(to_addr='+213', content='foo')
+        yield store.store_message('channel_id', api_from_message(msg))
+
+        msg_json = yield self.redis.hget(
+            'channel_id:outbound_messages:{}'.format(msg['message_id']),
+            'message')
+        self.assertEqual(msg_json, to_json(api_from_message(msg)))
 
     @inlineCallbacks
     def test_store_event(self):
@@ -415,8 +409,8 @@ class TestOutboundMessageStore(JunebugTestBase):
             'channel_id:outbound_messages:message_id', event['event_id'],
             event.to_json())
         yield self.redis.hset(
-            'channel_id:outbound_messages:message_id', 'event_url',
-            'test_url')
+            'channel_id:outbound_messages:message_id', 'message',
+            'test_message')
 
         stored_events = yield store.load_all_events('channel_id', 'message_id')
         self.assertEqual(stored_events, [event])

--- a/junebug/tests/test_workers.py
+++ b/junebug/tests/test_workers.py
@@ -219,8 +219,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
             sent_message_id='msg-21',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', self.url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': self.url,
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_ack(event)
         [req] = self.logging_api.requests
@@ -240,11 +243,12 @@ class TestMessageForwardingWorker(JunebugTestBase):
             sent_message_id='msg-21',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', self.url + '/auth/')
-        yield self.worker.outbounds.store_event_auth_token(
-            self.worker.channel_id, 'msg-21', "the-auth-token"
-        )
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': '{}/auth/'.format(self.url),
+                'event_auth_token': 'the-auth-token',
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_ack(event)
         [req] = self.logging_api.requests
@@ -264,8 +268,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         # Inject the auth parameters
         url = self.url.replace('http://', 'http://foo:bar@') + '/auth/'
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': url,
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_ack(event)
         [req] = self.logging_api.requests
@@ -305,8 +312,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
             sent_message_id='msg-21',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', "%s/bad/" % self.url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': "{}/bad/".format(self.url),
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_ack(event)
 
@@ -338,8 +348,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
             nack_reason='too many foos',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', self.url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': self.url,
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_nack(event)
         [req] = self.logging_api.requests
@@ -381,8 +394,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
             nack_reason='too many foos',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', "%s/bad/" % (self.url,))
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': '{}/bad/'.format(self.url),
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_nack(event)
 
@@ -414,8 +430,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
             delivery_status='pending',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', self.url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': self.url,
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_delivery_report(event)
         [req] = self.logging_api.requests
@@ -457,8 +476,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
             delivery_status='pending',
             timestamp='2015-09-22 15:39:44.827794')
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', "%s/bad/" % self.url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': '{}/bad/'.format(self.url),
+                'message_id': "msg-21",
+            })
 
         yield self.worker.consume_delivery_report(event)
 
@@ -494,8 +516,11 @@ class TestMessageForwardingWorker(JunebugTestBase):
 
         event['event_type'] = 'bad'
 
-        yield self.worker.outbounds.store_event_url(
-            self.worker.channel_id, 'msg-21', self.url)
+        yield self.worker.outbounds.store_message(
+            self.worker.channel_id, {
+                'event_url': self.url,
+                'message_id': "msg-21",
+            })
 
         yield self.worker._forward_event(event)
 


### PR DESCRIPTION
This PR adds a base class for router workers that includes some helpful methods that should be common across most routers.

The from address router will be created in a separate PR, as to have slightly smaller PRs