### PR TITLE
Have routers handle outbound messages from destinations

### DIFF
--- a/junebug/router/base.py
+++ b/junebug/router/base.py
@@ -417,6 +417,15 @@ class BaseRouterWorker(BaseWorker):
 
         return d.addCallback(attach_callbacks)
 
+    def consume_destination(self, destination_id, message_callback):
+        """
+        Attaches a callback function for outbound messages from the specified
+        destination ID. Callback functions will take 2 args, the destination id
+        and the message.
+        """
+        outbound_handler = partial(message_callback, destination_id)
+        self.connectors[destination_id].set_outbound_handler(outbound_handler)
+
     def send_inbound_to_destination(self, destination_id, message):
         """
         Publishes a message to the specified message forwarding worker.

--- a/junebug/router/from_address.py
+++ b/junebug/router/from_address.py
@@ -130,7 +130,13 @@ class FromAddressRouter(BaseRouterWorker):
             str(config.channel),
             self.handle_inbound_message,
             self.handle_inbound_event)
-        self.destinations = [d['config'] for d in config.destinations]
+        for destination in config.destinations:
+            self.consume_destination(
+                destination['id'], self.handle_outbound_message)
+
+    def handle_outbound_message(self, destinationid, message):
+        config = self.get_static_config()
+        return self.send_outbound_to_channel(str(config.channel), message)
 
     def handle_inbound_message(self, channelid, message):
         to_addr = message['to_addr']


### PR DESCRIPTION
Currently, the from address router doesn't handle outbound messages from destinations, and the base router worker class doesn't provide any helper functions to do so.

This PR adds both of those items.